### PR TITLE
feat(card): add header and body components

### DIFF
--- a/apps/web/public/components/card/demo/basic.ts
+++ b/apps/web/public/components/card/demo/basic.ts
@@ -1,10 +1,17 @@
 import { Component } from '@angular/core';
-
-import { ZardCardComponent } from '../card.component';
+import { ZardCardModule } from '@ngzard/ui';
 
 @Component({
-  standalone: true,
-  imports: [ZardCardComponent],
-  template: ` <z-card zTitle="Create project" zDescription="Deploy your new project in one-click."> Body content </z-card> `,
+  imports: [ZardCardModule],
+  template: `
+    <z-card>
+      <z-card-header>
+        <z-card-header-title>Card title</z-card-header-title>
+        <z-card-header-description>Card description</z-card-header-description>
+      </z-card-header>
+
+      <z-card-body> Card content </z-card-body>
+    </z-card>
+  `,
 })
 export class ZardDemoCardBasicComponent {}

--- a/apps/web/public/components/card/doc/api.md
+++ b/apps/web/public/components/card/doc/api.md
@@ -4,7 +4,39 @@
 
 > z-card is a component that provides a structured container for displaying content.
 
-| Property      | Description                        | Type          | Default |
-|--------------|------------------------------------|--------------|---------|
-| `[zTitle]`     | The title displayed in the card   | `string`      | `''`    |
-| `[zDescription]` | The description inside the card  | `string`      | `''`    |
+| Property      | Description        | Type          | Default |
+| --------------|--------------------|-------------- | ------- |
+| `[class]`     | Custom css classes | `string`      | `''`    |
+
+
+## [z-card-header] <span class="api-type-label component">Component</span>
+
+> z-card-header is a component that provides a structured container for displaying the header content.
+
+| Property      | Description        | Type          | Default |
+| --------------|--------------------|-------------- | ------- |
+| `[class]`     | Custom css classes | `string`      | `''`    |
+
+## [z-card-header-title] <span class="api-type-label component">Component</span>
+
+> z-card-header-title provides a structured container for displaying the header title.
+
+| Property      | Description        | Type          | Default |
+| --------------|--------------------|-------------- | ------- |
+| `[class]`     | Custom css classes | `string`      | `''`    |
+
+## [z-card-header-description] <span class="api-type-label component">Component</span>
+
+> z-card-header-description provides a structured container for displaying the header description.
+
+| Property      | Description        | Type          | Default |
+| --------------|--------------------|-------------- | ------- |
+| `[class]`     | Custom css classes | `string`      | `''`    |
+
+## [z-card-body] <span class="api-type-label component">Component</span>
+
+> z-card-body provides a structured container for displaying the body.
+
+| Property      | Description        | Type          | Default |
+| --------------|--------------------|-------------- | ------- |
+| `[class]`     | Custom css classes | `string`      | `''`    |

--- a/apps/web/public/components/card/doc/overview.md
+++ b/apps/web/public/components/card/doc/overview.md
@@ -3,5 +3,5 @@
 The Card component is used to display content and actions related to a single subject. It provides a structured layout with a title, description, and customizable styling.
 
 ```ts
-import { ZardCardComponent } from '@zard/card';
+import { ZardCardModule } from '@zard/card';
 ```

--- a/libs/zard/src/lib/components/card/card.component.spec.ts
+++ b/libs/zard/src/lib/components/card/card.component.spec.ts
@@ -1,0 +1,92 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ZardCardBodyComponent, ZardCardComponent, ZardCardHeaderComponent, ZardCardHeaderDescriptionComponent, ZardCardHeaderTitleComponent } from './card.component';
+
+import { Component } from '@angular/core';
+import { By } from '@angular/platform-browser';
+
+@Component({
+  selector: 'test-host-component',
+  template: `
+    <zard-card class="custom-class">
+      <zard-card-header class="custom-class">
+        <zard-card-header-title class="custom-class"> Title </zard-card-header-title>
+        <zard-card-header-description class="custom-class"> Description </zard-card-header-description>
+      </zard-card-header>
+      <zard-card-body class="custom-class"> Body </zard-card-body>
+    </zard-card>
+  `,
+})
+class TestHostComponent {}
+
+describe('ZardCardComponents', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [TestHostComponent, ZardCardComponent, ZardCardBodyComponent, ZardCardHeaderComponent, ZardCardHeaderTitleComponent, ZardCardHeaderDescriptionComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    fixture.detectChanges();
+  });
+
+  it('should create all components', () => {
+    const card = fixture.debugElement.query(By.directive(ZardCardComponent));
+    const cardBody = fixture.debugElement.query(By.directive(ZardCardBodyComponent));
+    const cardHeader = fixture.debugElement.query(By.directive(ZardCardHeaderComponent));
+    const cardHeaderTitle = fixture.debugElement.query(By.directive(ZardCardHeaderTitleComponent));
+    const cardHeaderDescription = fixture.debugElement.query(By.directive(ZardCardHeaderDescriptionComponent));
+
+    expect(card).toBeTruthy();
+    expect(cardBody).toBeTruthy();
+    expect(cardHeader).toBeTruthy();
+    expect(cardHeaderTitle).toBeTruthy();
+    expect(cardHeaderDescription).toBeTruthy();
+  });
+
+  it('should have default classes for ZardCardComponent', () => {
+    const card = fixture.debugElement.query(By.directive(ZardCardComponent)).nativeElement;
+    expect(card.classList).toContain('block');
+    expect(card.classList).toContain('rounded-lg');
+    expect(card.classList).toContain('border');
+    expect(card.classList).toContain('bg-card');
+    expect(card.classList).toContain('text-card-foreground');
+    expect(card.classList).toContain('shadow-sm');
+    expect(card.classList).toContain('w-full');
+    expect(card.classList).toContain('p-6');
+    expect(card.classList).toContain('custom-class');
+  });
+
+  it('should have default classes for ZardCardBodyComponent', () => {
+    const cardBody = fixture.debugElement.query(By.directive(ZardCardBodyComponent)).nativeElement;
+    expect(cardBody.classList).toContain('block');
+    expect(cardBody.classList).toContain('mt-6');
+    expect(cardBody.classList).toContain('custom-class');
+  });
+
+  it('should have default classes for ZardCardHeaderComponent', () => {
+    const cardHeader = fixture.debugElement.query(By.directive(ZardCardHeaderComponent)).nativeElement;
+    expect(cardHeader.classList).toContain('flex');
+    expect(cardHeader.classList).toContain('flex-col');
+    expect(cardHeader.classList).toContain('space-y-1.5');
+    expect(cardHeader.classList).toContain('pb-0');
+    expect(cardHeader.classList).toContain('gap-1.5');
+    expect(cardHeader.classList).toContain('custom-class');
+  });
+
+  it('should have default classes for ZardCardHeaderTitleComponent', () => {
+    const cardHeaderTitle = fixture.debugElement.query(By.directive(ZardCardHeaderTitleComponent)).nativeElement;
+    expect(cardHeaderTitle.classList).toContain('text-2xl');
+    expect(cardHeaderTitle.classList).toContain('font-semibold');
+    expect(cardHeaderTitle.classList).toContain('leading-none');
+    expect(cardHeaderTitle.classList).toContain('tracking-tight');
+    expect(cardHeaderTitle.classList).toContain('custom-class');
+  });
+
+  it('should have default classes for ZardCardHeaderDescriptionComponent', () => {
+    const cardHeaderDescription = fixture.debugElement.query(By.directive(ZardCardHeaderDescriptionComponent)).nativeElement;
+    expect(cardHeaderDescription.classList).toContain('text-sm');
+    expect(cardHeaderDescription.classList).toContain('text-muted-foreground');
+    expect(cardHeaderDescription.classList).toContain('custom-class');
+  });
+});

--- a/libs/zard/src/lib/components/card/card.component.ts
+++ b/libs/zard/src/lib/components/card/card.component.ts
@@ -3,42 +3,75 @@ import { ClassValue } from 'class-variance-authority/dist/types';
 import { ChangeDetectionStrategy, Component, computed, input, ViewEncapsulation } from '@angular/core';
 
 import { mergeClasses } from '../../shared/utils/utils';
-import { cardBodyVariants, cardHeaderVariants, cardVariants } from './card.variants';
+import { cardBodyVariants, cardHeaderDescriptionVariants, cardHeaderTitleVariants, cardHeaderVariants, cardVariants } from './card.variants';
+
+@Component({
+  selector: 'z-card-body',
+  exportAs: 'zCardBody',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: '<ng-content></ng-content>',
+  host: {
+    '[class]': 'classes()',
+  },
+})
+export class ZardCardBodyComponent {
+  protected readonly classes = computed(() => mergeClasses(cardBodyVariants()));
+}
+
+@Component({
+  selector: 'z-card-header',
+  exportAs: 'zCardHeader',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: '<ng-content></ng-content>',
+  host: {
+    '[class]': 'classes()',
+  },
+})
+export class ZardCardHeaderComponent {
+  readonly class = input<ClassValue>('');
+  protected readonly classes = computed(() => mergeClasses(cardHeaderVariants(), this.class()));
+}
+
+@Component({
+  selector: 'z-card-header-title',
+  exportAs: 'zCardHeaderTitle',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: '<ng-content></ng-content>',
+  host: {
+    '[class]': 'classes()',
+  },
+})
+export class ZardCardHeaderTitleComponent {
+  readonly class = input<ClassValue>('');
+  protected readonly classes = computed(() => mergeClasses(cardHeaderTitleVariants(), this.class()));
+}
+
+@Component({
+  selector: 'z-card-header-description',
+  exportAs: 'zCardHeaderDescription',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: '<ng-content></ng-content>',
+  host: {
+    '[class]': 'classes()',
+  },
+})
+export class ZardCardHeaderDescriptionComponent {
+  readonly class = input<ClassValue>('');
+  protected readonly classes = computed(() => mergeClasses(cardHeaderDescriptionVariants(), this.class()));
+}
 
 @Component({
   selector: 'z-card',
   exportAs: 'zCard',
-  standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
-  template: `
-    @if (zTitle()) {
-      <div [class]="headerClasses()">
-        <div class="text-2xl font-semibold leading-none tracking-tight">{{ zTitle() }}</div>
-
-        @if (zDescription()) {
-          <div class="text-sm text-muted-foreground">
-            {{ zDescription() }}
-          </div>
-        }
-      </div>
-    }
-
-    <div [class]="bodyClasses()">
-      <ng-content></ng-content>
-    </div>
-  `,
+  template: `<ng-content></ng-content>`,
   host: {
     '[class]': 'classes()',
   },
 })
 export class ZardCardComponent {
-  readonly zTitle = input<string>();
-  readonly zDescription = input<string>();
-
   readonly class = input<ClassValue>('');
 
   protected readonly classes = computed(() => mergeClasses(cardVariants(), this.class()));
-  protected readonly headerClasses = computed(() => mergeClasses(cardHeaderVariants()));
-  protected readonly bodyClasses = computed(() => mergeClasses(cardBodyVariants()));
 }

--- a/libs/zard/src/lib/components/card/card.module.ts
+++ b/libs/zard/src/lib/components/card/card.module.ts
@@ -1,0 +1,10 @@
+import { NgModule } from '@angular/core';
+import { ZardCardComponent, ZardCardBodyComponent, ZardCardHeaderComponent, ZardCardHeaderTitleComponent, ZardCardHeaderDescriptionComponent } from './card.component';
+
+const components = [ZardCardComponent, ZardCardBodyComponent, ZardCardHeaderComponent, ZardCardHeaderTitleComponent, ZardCardHeaderDescriptionComponent];
+
+@NgModule({
+  imports: components,
+  exports: components,
+})
+export class ZardCardModule {}

--- a/libs/zard/src/lib/components/card/card.variants.ts
+++ b/libs/zard/src/lib/components/card/card.variants.ts
@@ -1,16 +1,26 @@
 import { cva, VariantProps } from 'class-variance-authority';
 
-export const cardVariants = cva('block rounded-lg border bg-card text-card-foreground shadow-sm w-full', {
+export const cardVariants = cva('block rounded-lg border bg-card text-card-foreground shadow-sm w-full p-6', {
   variants: {},
 });
 export type ZardCardVariants = VariantProps<typeof cardVariants>;
 
-export const cardHeaderVariants = cva('flex flex-col space-y-1.5 p-6 pb-0 gap-1.5', {
+export const cardHeaderVariants = cva('flex flex-col space-y-1.5 pb-0 gap-1.5', {
   variants: {},
 });
 export type ZardCardHeaderVariants = VariantProps<typeof cardHeaderVariants>;
 
-export const cardBodyVariants = cva('p-6', {
+export const cardHeaderTitleVariants = cva('text-2xl font-semibold leading-none tracking-tight', {
+  variants: {},
+});
+export type ZardCardHeaderTitleVariants = VariantProps<typeof cardHeaderTitleVariants>;
+
+export const cardHeaderDescriptionVariants = cva('text-sm text-muted-foreground', {
+  variants: {},
+});
+export type ZardCardHeaderDescriptionVariants = VariantProps<typeof cardHeaderDescriptionVariants>;
+
+export const cardBodyVariants = cva('block mt-6', {
   variants: {},
 });
 export type ZardCardBodyVariants = VariantProps<typeof cardBodyVariants>;

--- a/libs/zard/src/lib/components/card/demo/basic.ts
+++ b/libs/zard/src/lib/components/card/demo/basic.ts
@@ -1,10 +1,19 @@
 import { Component } from '@angular/core';
 
-import { ZardCardComponent } from '../card.component';
+import { ZardCardModule } from '../card.module';
 
 @Component({
   standalone: true,
-  imports: [ZardCardComponent],
-  template: ` <z-card zTitle="Create project" zDescription="Deploy your new project in one-click."> Body content </z-card> `,
+  imports: [ZardCardModule],
+  template: `
+    <z-card>
+      <z-card-header>
+        <z-card-header-title>Card title</z-card-header-title>
+        <z-card-header-description>Card description</z-card-header-description>
+      </z-card-header>
+
+      <z-card-body> Card content </z-card-body>
+    </z-card>
+  `,
 })
 export class ZardDemoCardBasicComponent {}

--- a/libs/zard/src/lib/components/card/index.ts
+++ b/libs/zard/src/lib/components/card/index.ts
@@ -1,0 +1,2 @@
+export * from './card.component';
+export * from './card.module';


### PR DESCRIPTION
Create components to render each section of the card. 

![image](https://github.com/user-attachments/assets/b8583083-f566-49d7-84e8-ca6fd5088f0e)

![image](https://github.com/user-attachments/assets/43a6dbb7-a699-4f2f-a774-826e2eca44c1)

Fixes #40