### PR TITLE
🐛 fix: adjusting copy code button to be fixed into scroll

### DIFF
--- a/apps/web/src/app/shared/services/markdown.service.ts
+++ b/apps/web/src/app/shared/services/markdown.service.ts
@@ -105,9 +105,9 @@ export class MarkdownService {
             node.properties = {
               ...node.properties,
               className: [
-                'absolute',
+                'fixed',
+                '[&_span]:bg-transparent!',
                 'right-4',
-                'top-3',
                 'z-10',
                 'h-6',
                 'w-6',
@@ -117,12 +117,13 @@ export class MarkdownService {
                 'hover:bg-muted',
                 'cursor-pointer',
                 'rounded-md',
-                'bg-transparent',
+                'bg-secondary',
                 'p-1',
-                'text-xs',
+                'text-sm',
                 'flex',
                 'items-center',
                 'justify-center',
+                'mt-[-3px]',
               ],
             };
 


### PR DESCRIPTION
- Fix button position

<img width="777" height="351" alt="image" src="https://github.com/user-attachments/assets/aa93535e-1c9d-4461-859e-3a4be3a25bdc" />


The button's background cannot be transparent because in certain situations it becomes almost impossible to see it due to its position in relation to the displayed code.