### PR TITLE
🐛 fix: utils/number file not imported by the CLI

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,18 +1,18 @@
+import * as commentJson from 'comment-json';
 import { Command } from 'commander';
 import { existsSync } from 'fs';
-import fs from 'fs-extra';
-import path from 'path';
 import prompts from 'prompts';
 import { execa } from 'execa';
+import fs from 'fs-extra';
 import chalk from 'chalk';
-import ora from 'ora';
+import path from 'path';
 import { z } from 'zod';
-import * as commentJson from 'comment-json';
+import ora from 'ora';
 
+import { UTILS, POSTCSS_CONFIG, STYLES_WITH_VARIABLES } from '../utils/templates.js';
 import { DEFAULT_CONFIG, type Config } from '../utils/config.js';
 import { getProjectInfo } from '../utils/get-project-info.js';
 import { logger, spinner } from '../utils/logger.js';
-import { UTILS, POSTCSS_CONFIG, STYLES_WITH_VARIABLES } from '../utils/templates.js';
 
 export const init = new Command()
   .name('init')
@@ -231,17 +231,19 @@ async function setupTailwind(cwd: string, config: Config) {
   }
 }
 
-async function createUtils(cwd: string, config: Config) {
+export async function createUtils(cwd: string, config: Config) {
   const utilsPath = path.join(cwd, config.aliases.utils);
 
   if (!existsSync(utilsPath)) {
     await fs.mkdir(utilsPath, { recursive: true });
   }
 
-  const mergeClassesPath = path.join(utilsPath, 'merge-classes.ts');
+  for (const [fileName, content] of Object.entries(UTILS)) {
+    const filePath = path.join(utilsPath, `${fileName}.ts`);
 
-  if (!existsSync(mergeClassesPath)) {
-    await fs.writeFile(mergeClassesPath, UTILS.mergeClasses, 'utf8');
+    if (!existsSync(filePath)) {
+      await fs.writeFile(filePath, content.trim(), 'utf8');
+    }
   }
 }
 

--- a/packages/cli/src/utils/fetch-component.ts
+++ b/packages/cli/src/utils/fetch-component.ts
@@ -58,6 +58,9 @@ function transformContent(content: string, config: Config): string {
   // Transform the shared utils import
   transformed = transformed.replace(/from ['"]\.\.\/\.\.\/shared\/utils\/utils['"]/g, `from '@shared/utils/merge-classes'`);
 
+  // Transform the shared utils import (number)
+  transformed = transformed.replace(/from ['"]\.\.\/\.\.\/shared\/utils\/number['"]/g, `from '@shared/utils/number'`);
+
   // Transform relative component imports
   const componentImportRegex = /from ['"]\.\.\/([\w-]+)['"]/g;
   transformed = transformed.replace(componentImportRegex, `from '@shared/components/$1'`);

--- a/packages/cli/src/utils/templates.ts
+++ b/packages/cli/src/utils/templates.ts
@@ -6,7 +6,7 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
 `,
-  mergeClasses: `import { twMerge } from 'tailwind-merge';
+  'merge-classes': `import { twMerge } from 'tailwind-merge';
 import { ClassValue, clsx } from 'clsx';
 
 export function mergeClasses(...inputs: ClassValue[]) {
@@ -16,6 +16,20 @@ export function mergeClasses(...inputs: ClassValue[]) {
 export function transform(value: boolean | string): boolean {
   return typeof value === 'string' ? value === '' : value;
 }
+`,
+  number: `function clamp(value: number, [min, max]: [number, number]): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function roundToStep(value: number, min: number, step: number): number {
+  return Math.round((value - min) / step) * step + min;
+}
+
+function convertValueToPercentage(value: number, min: number, max: number): number {
+  return ((value - min) / (max - min)) * 100;
+}
+
+export { clamp, roundToStep, convertValueToPercentage };
 `,
 };
 


### PR DESCRIPTION
## What was done? 📝
- Fixed the issue where the `utils/number` file was not imported correctly by the CLI.
- Ensured that the import paths are correctly resolved and registered in the CLI configuration.

## Screenshots or GIFs 📸
<img width="1286" height="664" alt="bug-numberfile" src="https://github.com/user-attachments/assets/3560c409-886f-4dba-9483-9ece05cfa2b0" />

## Link to Issue 🔗
#146 

## Type of change 🏗
- [ ] New feature (non-breaking change that adds functionality)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Refactor (non-breaking change that improves the code or technical debt)
- [ ] Chore (none of the above, such as upgrading libraries)

## Breaking change 🚨
<!-- describe here the breaking changes -->

## Checklist 🧐
- [ ] Tested on Chrome
- [ ] Tested on Safari
- [ ] Tested Responsiveness
- [ ] No errors in the console
