### PR TITLE
fix: Merge state signals to prevent de-sync [issue-177]

### DIFF
--- a/apps/web/public/components/calendar/doc/api.md
+++ b/apps/web/public/components/calendar/doc/api.md
@@ -15,9 +15,10 @@
 
 ### Outputs
 
-| Name         | Type                 | Description                     |
-| ------------ | -------------------- | ------------------------------- |
-| `dateChange` | `EventEmitter<Date>` | Emitted when a date is selected |
+| Name          | Type                         | Description                                        |
+| ------------- | ---------------------------- | -------------------------------------------------- |
+| `valueChange` | `EventEmitter<Date \| null>` | Emitted when the date value is changed             |
+| `dateChange`  | `EventEmitter<Date>`         | Proxy of `valueChange` with filter for null values |
 
 ### CSS Custom Properties
 

--- a/libs/zard/src/lib/components/calendar/calendar.component.spec.ts
+++ b/libs/zard/src/lib/components/calendar/calendar.component.spec.ts
@@ -115,24 +115,22 @@ describe('ZardCalendarComponent', () => {
   describe('Navigation', () => {
     it('should navigate to previous month', () => {
       const initialDate = new Date(2024, 5, 1); // June 2024
-      component['navigationDate'].set(initialDate);
+      component['value'].set(initialDate);
 
       component['previousMonth']();
 
-      const currentDate = component['currentDate']();
-      expect(currentDate.getMonth()).toBe(4); // May
-      expect(currentDate.getFullYear()).toBe(2024);
+      expect(component['currentMonthValue']()).toBe('4'); // May
+      expect(component['currentYearValue']()).toBe('2024');
     });
 
     it('should navigate to next month', () => {
       const initialDate = new Date(2024, 5, 1); // June 2024
-      component['navigationDate'].set(initialDate);
+      component['value'].set(initialDate);
 
       component['nextMonth']();
 
-      const currentDate = component['currentDate']();
-      expect(currentDate.getMonth()).toBe(6); // July
-      expect(currentDate.getFullYear()).toBe(2024);
+      expect(component['currentMonthValue']()).toBe('6'); // July
+      expect(component['currentYearValue']()).toBe('2024');
     });
 
     it('should disable previous button when minDate prevents navigation', () => {
@@ -144,7 +142,7 @@ describe('ZardCalendarComponent', () => {
         value: () => minDate,
         writable: true,
       });
-      component['navigationDate'].set(currentDate);
+      component['value'].set(currentDate);
 
       expect(component['isPreviousDisabled']()).toBe(true);
     });
@@ -158,7 +156,7 @@ describe('ZardCalendarComponent', () => {
         value: () => maxDate,
         writable: true,
       });
-      component['navigationDate'].set(currentDate);
+      component['value'].set(currentDate);
 
       expect(component['isNextDisabled']()).toBe(true);
     });
@@ -167,18 +165,17 @@ describe('ZardCalendarComponent', () => {
   describe('Month and Year Selection', () => {
     it('should change month when valid month index is provided', () => {
       const initialDate = new Date(2024, 5, 1); // June 2024
-      component['navigationDate'].set(initialDate);
+      component['value'].set(initialDate);
 
       component['onMonthChange']('2'); // March (index 2)
 
-      const currentDate = component['currentDate']();
-      expect(currentDate.getMonth()).toBe(2);
-      expect(currentDate.getFullYear()).toBe(2024);
+      expect(component['currentMonthValue']()).toBe('2');
+      expect(component['currentYearValue']()).toBe('2024');
     });
 
     it('should not change month when invalid month index is provided', () => {
       const initialDate = new Date(2024, 5, 1); // June 2024
-      component['navigationDate'].set(initialDate);
+      component['value'].set(initialDate);
 
       component['onMonthChange']('invalid');
       component['onMonthChange']('12'); // Invalid month
@@ -190,47 +187,45 @@ describe('ZardCalendarComponent', () => {
 
     it('should change year when valid year is provided', () => {
       const initialDate = new Date(2024, 5, 1); // June 2024
-      component['navigationDate'].set(initialDate);
+      component['value'].set(initialDate);
 
       component['onYearChange']('2025');
 
-      const currentDate = component['currentDate']();
-      expect(currentDate.getFullYear()).toBe(2025);
-      expect(currentDate.getMonth()).toBe(5); // Should remain June
+      expect(component['currentYearValue']()).toBe('2025');
+      expect(component['currentMonthValue']()).toBe('5'); // Should remain June
     });
 
     it('should not change year when invalid year is provided', () => {
       const initialDate = new Date(2024, 5, 1); // June 2024
-      component['navigationDate'].set(initialDate);
+      component['value'].set(initialDate);
 
       component['onYearChange']('invalid');
       component['onYearChange']('1899'); // Too old (below 1900)
       component['onYearChange']('2101'); // Too new (above 2100)
       component['onYearChange'](''); // Empty string
 
-      const currentDate = component['currentDate']();
-      expect(currentDate.getFullYear()).toBe(2024); // Should remain 2024
+      expect(component['currentYearValue']()).toBe('2024'); // Should remain 2024
     });
 
     it('should return correct current month name', () => {
       const date = new Date(2024, 5, 1); // June 2024
-      component['navigationDate'].set(date);
+      component['value'].set(date);
 
-      expect(component['getCurrentMonthName']()).toBe('Jun');
+      expect(component['currentMonthName']()).toBe('Jun');
     });
 
     it('should return correct current year', () => {
       const date = new Date(2024, 5, 1); // June 2024
-      component['navigationDate'].set(date);
+      component['value'].set(date);
 
-      expect(component['getCurrentYear']()).toBe(2024);
+      expect(component['currentYearValue']()).toBe('2024');
     });
   });
 
   describe('Calendar Days Generation', () => {
     it('should generate calendar days for current month', () => {
       const date = new Date(2024, 0, 1); // January 2024
-      component['navigationDate'].set(date);
+      component['value'].set(date);
 
       const calendarDays = component['calendarDays']();
       expect(calendarDays.length).toBeGreaterThan(0);
@@ -242,7 +237,7 @@ describe('ZardCalendarComponent', () => {
 
     it('should mark today correctly', () => {
       const today = new Date();
-      component['navigationDate'].set(new Date(today.getFullYear(), today.getMonth(), 1));
+      component['value'].set(new Date(today.getFullYear(), today.getMonth(), 1));
 
       const calendarDays = component['calendarDays']();
       const todayDay = calendarDays.find(day => day.isToday);
@@ -255,12 +250,7 @@ describe('ZardCalendarComponent', () => {
 
     it('should mark selected date correctly', () => {
       const selectedDate = new Date(2024, 0, 15);
-      // Mock value signal
-      Object.defineProperty(component, 'value', {
-        value: () => selectedDate,
-        writable: true,
-      });
-      component['navigationDate'].set(new Date(2024, 0, 1));
+      component['value'].set(selectedDate);
 
       const calendarDays = component['calendarDays']();
       const selectedDay = calendarDays.find(day => day.isSelected);
@@ -399,13 +389,14 @@ describe('ZardCalendarComponent', () => {
   });
 
   describe('Focus Management', () => {
-    it('should reset navigation correctly', () => {
+    it('should reset navigation to current value on reset', () => {
       const testDate = new Date(2024, 5, 15);
-      component['navigationDate'].set(testDate);
+      component['value'].set(testDate);
 
+      component['previousMonth']();
       component.resetNavigation();
 
-      expect(component['navigationDate']()).toBeNull();
+      expect(component['currentDate']().getTime()).toEqual(testDate.getTime());
     });
   });
 
@@ -422,21 +413,21 @@ describe('ZardCalendarComponent', () => {
 
     it('should compute current month value correctly', () => {
       const date = new Date(2024, 5, 1); // June 2024
-      component['navigationDate'].set(date);
+      component['value'].set(date);
 
       expect(component['currentMonthValue']()).toBe('5');
     });
 
     it('should compute current year value correctly', () => {
       const date = new Date(2024, 5, 1); // June 2024
-      component['navigationDate'].set(date);
+      component['value'].set(date);
 
       expect(component['currentYearValue']()).toBe('2024');
     });
 
     it('should compute current month year correctly', () => {
       const date = new Date(2024, 5, 1); // June 2024
-      component['navigationDate'].set(date);
+      component['value'].set(date);
 
       expect(component['currentMonthYear']()).toBe('June 2024');
     });
@@ -445,7 +436,7 @@ describe('ZardCalendarComponent', () => {
   describe('Keyboard Navigation', () => {
     it('should handle arrow key navigation', () => {
       const initialDate = new Date(2024, 0, 15); // January 15, 2024
-      component['navigationDate'].set(initialDate);
+      component['value'].set(initialDate);
 
       const event = new KeyboardEvent('keydown', { key: 'ArrowRight' });
       jest.spyOn(event, 'preventDefault');
@@ -457,7 +448,7 @@ describe('ZardCalendarComponent', () => {
 
     it('should handle Home and End keys', () => {
       const initialDate = new Date(2024, 0, 15); // January 15, 2024
-      component['navigationDate'].set(initialDate);
+      component['value'].set(initialDate);
 
       const homeEvent = new KeyboardEvent('keydown', { key: 'Home' });
       const endEvent = new KeyboardEvent('keydown', { key: 'End' });
@@ -474,7 +465,7 @@ describe('ZardCalendarComponent', () => {
 
     it('should handle PageUp and PageDown for month navigation', () => {
       const initialDate = new Date(2024, 5, 1); // June 2024
-      component['navigationDate'].set(initialDate);
+      component['value'].set(initialDate);
 
       const pageUpEvent = new KeyboardEvent('keydown', { key: 'PageUp' });
       jest.spyOn(pageUpEvent, 'preventDefault');
@@ -483,12 +474,12 @@ describe('ZardCalendarComponent', () => {
 
       expect(pageUpEvent.preventDefault).toHaveBeenCalled();
       // Should navigate to previous month (May)
-      expect(component['currentDate']().getMonth()).toBe(4);
+      expect(component['currentMonthValue']()).toBe('4');
     });
 
     it('should handle Ctrl+PageUp and Ctrl+PageDown for year navigation', () => {
       const initialDate = new Date(2024, 5, 1); // June 2024
-      component['navigationDate'].set(initialDate);
+      component['value'].set(initialDate);
 
       const ctrlPageUpEvent = new KeyboardEvent('keydown', {
         key: 'PageUp',
@@ -500,17 +491,13 @@ describe('ZardCalendarComponent', () => {
 
       expect(ctrlPageUpEvent.preventDefault).toHaveBeenCalled();
       // Should navigate to previous year (2023)
-      expect(component['currentDate']().getFullYear()).toBe(2023);
+      expect(component['currentYearValue']()).toBe('2023');
     });
 
     it('should handle Enter and Space for date selection', () => {
       const initialDate = new Date(2024, 0, 15);
-      // Mock value signal
-      Object.defineProperty(component, 'value', {
-        value: () => initialDate,
-        writable: true,
-      });
-      component['navigationDate'].set(new Date(2024, 0, 1));
+      component['value'].set(initialDate);
+      component['value'].set(new Date(2024, 0, 1));
 
       const enterEvent = new KeyboardEvent('keydown', { key: 'Enter' });
 

--- a/libs/zard/src/lib/components/calendar/calendar.component.ts
+++ b/libs/zard/src/lib/components/calendar/calendar.component.ts
@@ -87,7 +87,7 @@ export type { ZardCalendarVariants };
             <button
               [id]="getDayId(i)"
               [class]="dayButtonClasses(day)"
-              (click)="selectDate(day.date)"
+              (click)="selectDate(day.date, i)"
               [disabled]="day.isDisabled"
               [attr.aria-selected]="day.isSelected"
               [attr.aria-label]="getDayAriaLabel(day)"
@@ -110,6 +110,7 @@ export class ZardCalendarComponent {
     const value = this.currentDate();
     this.currentMonthValue.set(value.getMonth().toString());
     this.currentYearValue.set(value.getFullYear().toString());
+    this.focusedDayIndex.set(-1);
   }
   readonly class = input<ClassValue>('');
   readonly zSize = input<ZardCalendarVariants['zSize']>('default');
@@ -188,7 +189,11 @@ export class ZardCalendarComponent {
     return date.toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
   });
 
-  protected readonly currentMonthName = computed(() => this.months[this.currentDate().getMonth()]);
+  protected readonly currentMonthName = computed(() => {
+    const selectedMonth = parseInt(this.currentMonthValue());
+    if (!isNaN(selectedMonth) && this.months[selectedMonth]) return this.months[selectedMonth];
+    return this.months[this.currentDate().getMonth()];
+  });
 
   protected onMonthChange(monthIndex: string): void {
     if (!monthIndex || monthIndex.trim() === '') {
@@ -202,9 +207,11 @@ export class ZardCalendarComponent {
       return;
     }
 
-    const current = this.currentDate();
-    const newDate = new Date(current.getFullYear(), parsedMonth, 1);
+    const currentDate = this.currentDate();
+    const selectedYear = parseInt(this.currentYearValue());
+    const newDate = new Date(isNaN(selectedYear) ? currentDate.getFullYear() : selectedYear, parsedMonth, 1);
     this.currentMonthValue.set(newDate.getMonth().toString());
+    this.focusedDayIndex.set(-1);
   }
 
   protected onYearChange(year: string): void {
@@ -219,20 +226,23 @@ export class ZardCalendarComponent {
       return;
     }
 
-    const current = this.currentDate();
-    const newDate = new Date(parsedYear, current.getMonth(), 1);
+    const currentDate = this.currentDate();
+    const selectedMonth = parseInt(this.currentMonthValue());
+    const newDate = new Date(parsedYear, isNaN(selectedMonth) ? currentDate.getMonth() : selectedMonth, 1);
     this.currentYearValue.set(newDate.getFullYear().toString());
+    this.focusedDayIndex.set(-1);
   }
 
   protected readonly calendarDays = computed(() => {
     const currentDate = this.currentDate();
-    const selectedDate = this.value();
+    const navigationDate = new Date(parseInt(this.currentYearValue()), parseInt(this.currentMonthValue()), currentDate.getDate());
+    const selectedDate = isNaN(navigationDate.getTime()) ? currentDate : navigationDate;
     const today = new Date();
     const minDate = this.minDate();
     const maxDate = this.maxDate();
 
-    const year = currentDate.getFullYear();
-    const month = currentDate.getMonth();
+    const year = selectedDate.getFullYear();
+    const month = selectedDate.getMonth();
 
     // Get first day of the month
     const firstDay = new Date(year, month, 1);
@@ -254,7 +264,7 @@ export class ZardCalendarComponent {
       const date = new Date(currentWeekDate);
       const isCurrentMonth = date.getMonth() === month;
       const isToday = this.isSameDay(date, today);
-      const isSelected = selectedDate ? this.isSameDay(date, selectedDate) : false;
+      const isSelected = currentDate ? this.isSameDay(date, currentDate) : false;
       const isDisabled = this.disabled() || this.isDateDisabled(date, minDate, maxDate);
 
       days.push({
@@ -284,15 +294,19 @@ export class ZardCalendarComponent {
   }
 
   protected previousMonth() {
-    const current = this.currentDate();
-    const previous = new Date(current.getFullYear(), current.getMonth() - 1, 1);
+    const currentDate = this.currentDate();
+    const currentMonth = parseInt(this.currentMonthValue());
+    const previous = new Date(currentDate.getFullYear(), (isNaN(currentMonth) ? currentDate.getMonth() : currentMonth) - 1, 1);
     this.currentMonthValue.set(previous.getMonth().toString());
+    this.focusedDayIndex.set(-1);
   }
 
   protected nextMonth() {
-    const current = this.currentDate();
-    const next = new Date(current.getFullYear(), current.getMonth() + 1, 1);
+    const currentDate = this.currentDate();
+    const currentMonth = parseInt(this.currentMonthValue());
+    const next = new Date(currentDate.getFullYear(), (isNaN(currentMonth) ? currentDate.getMonth() : currentMonth) + 1, 1);
     this.currentMonthValue.set(next.getMonth().toString());
+    this.focusedDayIndex.set(-1);
   }
 
   protected isPreviousDisabled(): boolean {
@@ -301,10 +315,11 @@ export class ZardCalendarComponent {
     const minDate = this.minDate();
     if (!minDate) return false;
 
-    const current = this.currentDate();
-    const lastDayOfPreviousMonth = new Date(current.getFullYear(), current.getMonth(), 0);
+    const currentDate = this.currentDate();
+    const currentMonth = parseInt(this.currentMonthValue());
+    const lastDayOfPreviousMonth = new Date(currentDate.getFullYear(), isNaN(currentMonth) ? currentDate.getMonth() : currentMonth, 0);
 
-    return lastDayOfPreviousMonth < minDate;
+    return lastDayOfPreviousMonth.getTime() < minDate.getTime();
   }
 
   protected isNextDisabled(): boolean {
@@ -313,13 +328,14 @@ export class ZardCalendarComponent {
     const maxDate = this.maxDate();
     if (!maxDate) return false;
 
-    const current = this.currentDate();
-    const nextMonth = new Date(current.getFullYear(), current.getMonth() + 1, 1);
+    const currentDate = this.currentDate();
+    const currentMonth = parseInt(this.currentMonthValue());
+    const nextMonth = new Date(currentDate.getFullYear(), (isNaN(currentMonth) ? currentDate.getMonth() : currentMonth) + 1, 1);
 
-    return nextMonth > maxDate;
+    return nextMonth.getTime() > maxDate.getTime();
   }
 
-  selectDate(date: Date) {
+  selectDate(date: Date, i?: number) {
     if (this.disabled()) return;
 
     const minDate = this.minDate();
@@ -328,6 +344,7 @@ export class ZardCalendarComponent {
     if (this.isDateDisabled(date, minDate, maxDate)) return;
 
     this.value.set(date);
+    this.focusedDayIndex.set(i ?? this.calendarDays().findIndex(day => this.isSameDay(day.date, date)));
   }
 
   protected getDayAriaLabel(day: CalendarDay): string {
@@ -426,7 +443,7 @@ export class ZardCalendarComponent {
         event.preventDefault();
         const focusedDay = days[currentIndex];
         if (focusedDay && !focusedDay.isDisabled) {
-          this.selectDate(focusedDay.date);
+          this.selectDate(focusedDay.date, currentIndex);
         }
         return;
       }


### PR DESCRIPTION
## What was done? 📝
- Merged calendar state signals (selectedDate, navigationDate & value) to prevent de-sync issues between them.
- Migrated navigationDate to two linkedSignals that are bound to the value model to enable "viewing" other months/years.
- Changed dateChange event to trigger on any value change (filtering out nulls - keeps API non-breaking)
- Changed currentDate to be the current value or today

## Link to Issue 🔗
[Issue 177](https://github.com/zard-ui/zardui/issues/177)

## Type of change 🏗
- [ ] New feature (non-breaking change that adds functionality)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Refactor (non-breaking change that improves the code or technical debt)
- [ ] Chore (none of the above, such as upgrading libraries)

## Breaking change 🚨
No breaking changes

## Checklist 🧐
- [x] Tested on Chrome
- [ ] Tested on Safari
- [ ] Tested Responsiveness - no UI changes
- [x] No errors in the console
