### PR TITLE
Task/#202 update select doc

### DIFF
--- a/apps/web/public/components/calendar/demo/sizes.md
+++ b/apps/web/public/components/calendar/demo/sizes.md
@@ -1,9 +1,9 @@
 ```angular-ts showLineNumbers copyButton
 import { Component, computed, signal } from '@angular/core';
 
+import { ZardCalendarComponent, ZardCalendarVariants } from '../calendar.component';
 import { ZardSelectItemComponent } from '../../select/select-item.component';
 import { ZardSelectComponent } from '../../select/select.component';
-import { ZardCalendarComponent, ZardCalendarVariants } from '../calendar.component';
 
 @Component({
   standalone: true,
@@ -12,10 +12,10 @@ import { ZardCalendarComponent, ZardCalendarVariants } from '../calendar.compone
     <div class="space-y-6">
       <div class="flex items-center gap-4">
         <label class="text-sm font-medium">Size:</label>
-        <z-select [value]="selectedSize() || 'default'" [label]="sizeLabel()" (selectionChange)="onSizeChange($event)" class="min-w-[120px]">
-          <z-select-item value="sm">Small</z-select-item>
-          <z-select-item value="default">Default</z-select-item>
-          <z-select-item value="lg">Large</z-select-item>
+        <z-select [zValue]="selectedSize() || 'default'" [zLabel]="sizeLabel()" (zSelectionChange)="onSizeChange($event)" class="min-w-[120px]">
+          <z-select-item zValue="sm">Small</z-select-item>
+          <z-select-item zValue="default">Default</z-select-item>
+          <z-select-item zValue="lg">Large</z-select-item>
         </z-select>
       </div>
 

--- a/apps/web/public/components/form/demo/complex.md
+++ b/apps/web/public/components/form/demo/complex.md
@@ -2,11 +2,11 @@
 import { ChangeDetectionStrategy, Component, inject, signal, ViewEncapsulation } from '@angular/core';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 
-import { ZardButtonComponent } from '../../button/button.component';
-import { ZardCheckboxComponent } from '../../checkbox/checkbox.component';
-import { ZardInputDirective } from '../../input/input.directive';
 import { ZardSelectItemComponent } from '../../select/select-item.component';
+import { ZardCheckboxComponent } from '../../checkbox/checkbox.component';
 import { ZardSelectComponent } from '../../select/select.component';
+import { ZardButtonComponent } from '../../button/button.component';
+import { ZardInputDirective } from '../../input/input.directive';
 import { ZardFormModule } from '../form.module';
 
 interface FormData {
@@ -68,7 +68,7 @@ interface FormData {
         <z-form-control [errorMessage]="isFieldInvalid('country') ? 'Please select a country' : ''">
           <z-select id="country" formControlName="country" placeholder="Select your country">
             @for (country of countries; track country.value) {
-              <z-select-item [value]="country.value">{{ country.label }}</z-select-item>
+              <z-select-item [zValue]="country.value">{{ country.label }}</z-select-item>
             }
           </z-select>
         </z-form-control>

--- a/apps/web/public/components/select/demo/default.md
+++ b/apps/web/public/components/select/demo/default.md
@@ -9,12 +9,12 @@ import { ZardSelectComponent } from '../select.component';
   standalone: true,
   imports: [FormsModule, ZardSelectComponent, ZardSelectItemComponent],
   template: `
-    <z-select placeholder="Selecione uma fruta" [(ngModel)]="defaultValue">
-      <z-select-item value="apple">Apple</z-select-item>
-      <z-select-item value="banana">Banana</z-select-item>
-      <z-select-item value="blueberry">Blueberry</z-select-item>
-      <z-select-item value="grapes">Grapes</z-select-item>
-      <z-select-item value="pineapple" disabled>Pineapple</z-select-item>
+    <z-select zPlaceholder="Selecione uma fruta" [(ngModel)]="defaultValue">
+      <z-select-item zValue="apple">Apple</z-select-item>
+      <z-select-item zValue="banana">Banana</z-select-item>
+      <z-select-item zValue="blueberry">Blueberry</z-select-item>
+      <z-select-item zValue="grapes">Grapes</z-select-item>
+      <z-select-item zValue="pineapple" zDisabled>Pineapple</z-select-item>
     </z-select>
   `,
 })

--- a/apps/web/public/components/select/doc/api.md
+++ b/apps/web/public/components/select/doc/api.md
@@ -4,14 +4,14 @@
 
 > A customizable select component that allows single value selection.
 
-| Input           | Description                   | Type                        | Default                 |
-| --------------- | ----------------------------- | --------------------------- | ----------------------- |
-| `[class]`       | Custom CSS classes            | `string`                    | `''`                    |
-| `[zSize]`       | Sets the select size          | `'default' \| 'sm' \| 'lg'` | `'default'`             |
-| `[placeholder]` | Placeholder text              | `string`                    | `'Select an option...'` |
-| `[value]`       | Selected value                | `string`                    | `''`                    |
-| `[label]`       | Optional label for the select | `string`                    | `''`                    |
-| `[disabled]`    | Disables the select           | `boolean`                   | `false`                 |
+| Input            | Description                   | Type                        | Default                 |
+| ---------------- | ----------------------------- | --------------------------- | ----------------------- |
+| `[class]`        | Custom CSS classes            | `string`                    | `''`                    |
+| `[zSize]`        | Sets the select size          | `'default' \| 'sm' \| 'lg'` | `'default'`             |
+| `[zPlaceholder]` | Placeholder text              | `string`                    | `'Select an option...'` |
+| `[zValue]`       | Selected value                | `string`                    | `''`                    |
+| `[zLabel]`       | Optional label for the select | `string`                    | `''`                    |
+| `[zDisabled]`    | Disables the select           | `boolean`                   | `false`                 |
 
 | Output              | Description                             | Payload  |
 | ------------------- | --------------------------------------- | -------- |
@@ -21,8 +21,8 @@
 
 > Represents an individual item inside a `z-select` component.
 
-| Input        | Description                         | Type      | Default |
-| ------------ | ----------------------------------- | --------- | ------- |
-| `[class]`    | Custom CSS classes                  | `string`  | `''`    |
-| `[value]`    | The value associated with this item | `string`  | `''`    |
-| `[disabled]` | Disables selection for this item    | `boolean` | `false` |
+| Input         | Description                         | Type      | Default |
+| ------------- | ----------------------------------- | --------- | ------- |
+| `[class]`     | Custom CSS classes                  | `string`  | `''`    |
+| `[zValue]`    | The value associated with this item | `string`  | `''`    |
+| `[zDisabled]` | Disables selection for this item    | `boolean` | `false` |

--- a/apps/web/public/installation/manual/accordion.md
+++ b/apps/web/public/installation/manual/accordion.md
@@ -1,8 +1,11 @@
+
+
 ```angular-ts title="accordion.component.ts" copyButton showLineNumbers
 import { AfterContentInit, ChangeDetectionStrategy, Component, contentChildren, input, ViewEncapsulation } from '@angular/core';
-import type { ClassValue } from 'clsx';
 
 import { ZardAccordionItemComponent } from './accordion-item.component';
+
+import type { ClassValue } from 'clsx';
 
 @Component({
   selector: 'z-accordion',
@@ -86,11 +89,14 @@ export class ZardAccordionComponent implements AfterContentInit {
 
 ```
 
+
+
 ```angular-ts title="accordion-item.component.ts" copyButton showLineNumbers
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, computed, inject, input, signal, ViewEncapsulation } from '@angular/core';
-import type { ClassValue } from 'clsx';
 
 import { ZardAccordionComponent } from './accordion.component';
+
+import type { ClassValue } from 'clsx';
 
 @Component({
   selector: 'z-accordion-item',
@@ -164,3 +170,4 @@ export class ZardAccordionItemComponent {
 }
 
 ```
+

--- a/apps/web/public/installation/manual/alert-dialog.md
+++ b/apps/web/public/installation/manual/alert-dialog.md
@@ -396,7 +396,7 @@ export class ZardAlertDialogService {
 
   private open<T>(componentOrTemplateRef: ContentType<T>, config: ZardAlertDialogOptions<T>) {
     const overlayRef = this.createOverlay();
-    
+
     if (!overlayRef) {
       // Return a mock alert dialog ref for SSR environments
       return new ZardAlertDialogRef(undefined as any, config, undefined as any);

--- a/apps/web/public/installation/manual/button.md
+++ b/apps/web/public/installation/manual/button.md
@@ -38,7 +38,16 @@ export class ZardButtonComponent {
   readonly zLoading = input(false, { transform });
 
   protected readonly classes = computed(() =>
-    mergeClasses(buttonVariants({ zType: this.zType(), zSize: this.zSize(), zShape: this.zShape(), zFull: this.zFull(), zLoading: this.zLoading() }), this.class()),
+    mergeClasses(
+      buttonVariants({
+        zType: this.zType(),
+        zSize: this.zSize(),
+        zShape: this.zShape(),
+        zFull: this.zFull(),
+        zLoading: this.zLoading(),
+      }),
+      this.class(),
+    ),
   );
 }
 
@@ -50,7 +59,7 @@ export class ZardButtonComponent {
 import { cva, VariantProps } from 'class-variance-authority';
 
 export const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "cursor-pointer inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all active:scale-95 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   {
     variants: {
       zType: {

--- a/apps/web/public/installation/manual/calendar.md
+++ b/apps/web/public/installation/manual/calendar.md
@@ -1,6 +1,9 @@
+
+
 ```angular-ts title="calendar.component.ts" copyButton showLineNumbers
 import { ChangeDetectionStrategy, Component, computed, ElementRef, input, linkedSignal, model, signal, viewChild, ViewEncapsulation } from '@angular/core';
 import { outputFromObservable, outputToObservable } from '@angular/core/rxjs-interop';
+import { filter } from 'rxjs';
 
 import { calendarDayButtonVariants, calendarDayVariants, calendarNavVariants, calendarVariants, calendarWeekdayVariants, ZardCalendarVariants } from './calendar.variants';
 import { ZardSelectItemComponent } from '../select/select-item.component';
@@ -8,7 +11,6 @@ import { ZardSelectComponent } from '../select/select.component';
 import { ZardButtonComponent } from '../button/button.component';
 import type { ClassValue } from '../../shared/utils/utils';
 import { mergeClasses } from '../../shared/utils/utils';
-import { filter } from 'rxjs';
 
 export interface CalendarDay {
   date: Date;
@@ -53,16 +55,16 @@ export type { ZardCalendarVariants };
         <!-- Month and Year Selectors -->
         <div class="flex items-center space-x-2">
           <!-- Month Select -->
-          <z-select [size]="selectSize()" class="min-w-[120px]" [value]="currentMonthValue()" [label]="currentMonthName()" (selectionChange)="onMonthChange($event)">
+          <z-select [zSize]="selectSize()" class="min-w-[120px]" [zValue]="currentMonthValue()" [zLabel]="currentMonthName()" (zSelectionChange)="onMonthChange($event)">
             @for (month of months; track $index) {
-              <z-select-item [value]="$index.toString()">{{ month }}</z-select-item>
+              <z-select-item [zValue]="$index.toString()">{{ month }}</z-select-item>
             }
           </z-select>
 
           <!-- Year Select -->
-          <z-select [size]="selectSize()" class="min-w-[80px]" [value]="currentYearValue()" [label]="currentYearValue()" (selectionChange)="onYearChange($event)">
+          <z-select [zSize]="selectSize()" class="min-w-[80px]" [zValue]="currentYearValue()" [zLabel]="currentYearValue()" (zSelectionChange)="onYearChange($event)">
             @for (year of availableYears(); track year) {
-              <z-select-item [value]="year.toString()">{{ year }}</z-select-item>
+              <z-select-item [zValue]="year.toString()">{{ year }}</z-select-item>
             }
           </z-select>
         </div>
@@ -593,6 +595,8 @@ export class ZardCalendarComponent {
 
 ```
 
+
+
 ```angular-ts title="calendar.variants.ts" copyButton showLineNumbers
 import { cva, VariantProps } from 'class-variance-authority';
 
@@ -701,3 +705,4 @@ export type ZardCalendarDayVariants = VariantProps<typeof calendarDayVariants>;
 export type ZardCalendarDayButtonVariants = VariantProps<typeof calendarDayButtonVariants>;
 
 ```
+

--- a/apps/web/public/installation/manual/checkbox.md
+++ b/apps/web/public/installation/manual/checkbox.md
@@ -3,10 +3,11 @@
 ```angular-ts title="checkbox.component.ts" copyButton showLineNumbers
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, computed, forwardRef, inject, input, output, ViewEncapsulation } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
-import type { ClassValue } from 'clsx';
 
-import { checkboxLabelVariants, checkboxVariants, ZardCheckboxVariants } from './checkbox.variants';
 import { mergeClasses, transform } from '../../shared/utils/utils';
+import { checkboxLabelVariants, checkboxVariants, ZardCheckboxVariants } from './checkbox.variants';
+
+import type { ClassValue } from 'clsx';
 
 type OnTouchedType = () => any;
 type OnChangeType = (value: any) => void;

--- a/apps/web/public/installation/manual/command.md
+++ b/apps/web/public/installation/manual/command.md
@@ -1,6 +1,7 @@
+
+
 ```angular-ts title="command.component.ts" copyButton showLineNumbers
 import {
-  AfterContentInit,
   ChangeDetectionStrategy,
   Component,
   computed,
@@ -16,12 +17,13 @@ import {
   ViewEncapsulation,
 } from '@angular/core';
 import { ControlValueAccessor, FormsModule, NG_VALUE_ACCESSOR } from '@angular/forms';
-import type { ClassValue } from 'clsx';
 
-import { commandVariants, ZardCommandVariants } from './command.variants';
-import { ZardCommandOptionComponent } from './command-option.component';
-import { ZardCommandInputComponent } from './command-input.component';
 import { mergeClasses } from '../../shared/utils/utils';
+import { ZardCommandInputComponent } from './command-input.component';
+import { ZardCommandOptionComponent } from './command-option.component';
+import { commandVariants, ZardCommandVariants } from './command.variants';
+
+import type { ClassValue } from 'clsx';
 
 export interface ZardCommandOption {
   value: unknown;
@@ -259,6 +261,8 @@ export class ZardCommandComponent implements ControlValueAccessor {
 
 ```
 
+
+
 ```angular-ts title="command.variants.ts" copyButton showLineNumbers
 import { cva, VariantProps } from 'class-variance-authority';
 
@@ -334,14 +338,16 @@ export type ZardCommandItemVariants = VariantProps<typeof commandItemVariants>;
 
 ```
 
+
+
 ```angular-ts title="command-divider.component.ts" copyButton showLineNumbers
 import { ChangeDetectionStrategy, Component, computed, inject, input, ViewEncapsulation } from '@angular/core';
-import type { ClassValue } from 'clsx';
 
-import { commandSeparatorVariants } from './command.variants';
-import { ZardCommandComponent } from './command.component';
 import { mergeClasses } from '../../shared/utils/utils';
+import { ZardCommandComponent } from './command.component';
+import { commandSeparatorVariants } from './command.variants';
 
+import type { ClassValue } from 'clsx';
 @Component({
   selector: 'z-command-divider',
   exportAs: 'zCommandDivider',
@@ -377,14 +383,17 @@ export class ZardCommandDividerComponent {
 
 ```
 
+
+
 ```angular-ts title="command-empty.component.ts" copyButton showLineNumbers
 import { ChangeDetectionStrategy, Component, computed, inject, input, ViewEncapsulation } from '@angular/core';
-import type { ClassValue } from 'clsx';
 
+import { mergeClasses } from '../../shared/utils/utils';
 import { ZardCommandJsonComponent } from './command-json.component';
 import { ZardCommandComponent } from './command.component';
 import { commandEmptyVariants } from './command.variants';
-import { mergeClasses } from '../../shared/utils/utils';
+
+import type { ClassValue } from 'clsx';
 
 @Component({
   selector: 'z-command-empty',
@@ -429,7 +438,11 @@ export class ZardCommandEmptyComponent {
 
 ```
 
+
+
 ```angular-ts title="command-input.component.ts" copyButton showLineNumbers
+import { Subject, switchMap, takeUntil, timer } from 'rxjs';
+
 import {
   ChangeDetectionStrategy,
   Component,
@@ -447,14 +460,13 @@ import {
   ViewEncapsulation,
 } from '@angular/core';
 import { ControlValueAccessor, FormsModule, NG_VALUE_ACCESSOR } from '@angular/forms';
-import type { ClassValue } from 'clsx';
-import { Subject, switchMap, takeUntil, timer } from 'rxjs';
 
+import { mergeClasses } from '../../shared/utils/utils';
 import { ZardCommandJsonComponent } from './command-json.component';
 import { ZardCommandComponent } from './command.component';
 import { commandInputVariants } from './command.variants';
-import { mergeClasses } from '../../shared/utils/utils';
 
+import type { ClassValue } from 'clsx';
 @Component({
   selector: 'z-command-input',
   exportAs: 'zCommandInput',
@@ -604,6 +616,8 @@ export class ZardCommandInputComponent implements ControlValueAccessor, OnInit, 
 }
 
 ```
+
+
 
 ```angular-ts title="command-json.component.ts" copyButton showLineNumbers
 import type { ClassValue } from 'clsx';
@@ -895,6 +909,8 @@ export class ZardCommandJsonComponent implements ControlValueAccessor {
 
 ```
 
+
+
 ```angular-ts title="command-list.component.ts" copyButton showLineNumbers
 import type { ClassValue } from 'clsx';
 
@@ -923,14 +939,17 @@ export class ZardCommandListComponent {
 
 ```
 
+
+
 ```angular-ts title="command-option-group.component.ts" copyButton showLineNumbers
 import { AfterContentInit, ChangeDetectionStrategy, Component, computed, contentChildren, inject, input, ViewEncapsulation } from '@angular/core';
-import type { ClassValue } from 'clsx';
 
-import { commandGroupHeadingVariants, commandGroupVariants } from './command.variants';
+import { mergeClasses } from '../../shared/utils/utils';
 import { ZardCommandOptionComponent } from './command-option.component';
 import { ZardCommandComponent } from './command.component';
-import { mergeClasses } from '../../shared/utils/utils';
+import { commandGroupHeadingVariants, commandGroupVariants } from './command.variants';
+
+import type { ClassValue } from 'clsx';
 
 @Component({
   selector: 'z-command-option-group',
@@ -985,13 +1004,16 @@ export class ZardCommandOptionGroupComponent implements AfterContentInit {
 
 ```
 
+
+
 ```angular-ts title="command-option.component.ts" copyButton showLineNumbers
 import { ChangeDetectionStrategy, Component, computed, ElementRef, inject, input, signal, ViewEncapsulation } from '@angular/core';
-import type { ClassValue } from 'clsx';
 
-import { commandItemVariants, commandShortcutVariants, ZardCommandItemVariants } from './command.variants';
 import { mergeClasses, transform } from '../../shared/utils/utils';
 import { ZardCommandComponent } from './command.component';
+import { commandItemVariants, commandShortcutVariants, ZardCommandItemVariants } from './command.variants';
+
+import type { ClassValue } from 'clsx';
 
 @Component({
   selector: 'z-command-option',
@@ -1092,6 +1114,8 @@ export class ZardCommandOptionComponent {
 
 ```
 
+
+
 ```angular-ts title="command.module.ts" copyButton showLineNumbers
 import { FormsModule } from '@angular/forms';
 import { NgModule } from '@angular/core';
@@ -1123,3 +1147,4 @@ const COMMAND_COMPONENTS = [
 export class ZardCommandModule {}
 
 ```
+

--- a/apps/web/public/installation/manual/dialog.md
+++ b/apps/web/public/installation/manual/dialog.md
@@ -1,5 +1,3 @@
-
-
 ```angular-ts title="dialog.component.ts" copyButton showLineNumbers
 import {
   ChangeDetectionStrategy,
@@ -181,8 +179,6 @@ export class ZardDialogModule {}
 
 ```
 
-
-
 ```angular-ts title="dialog.variants.ts" copyButton showLineNumbers
 import { cva, VariantProps } from 'class-variance-authority';
 
@@ -192,8 +188,6 @@ export const dialogVariants = cva(
 export type ZardDialogVariants = VariantProps<typeof dialogVariants>;
 
 ```
-
-
 
 ```angular-ts title="dialog-ref.ts" copyButton showLineNumbers
 import { EventEmitter, Inject, inject, PLATFORM_ID } from '@angular/core';
@@ -273,8 +267,6 @@ export class ZardDialogRef<T = any, R = any, U = any> {
 }
 
 ```
-
-
 
 ```angular-ts title="dialog.service.ts" copyButton showLineNumbers
 import { inject, Injectable, InjectionToken, Injector, PLATFORM_ID, TemplateRef } from '@angular/core';
@@ -375,4 +367,3 @@ export class ZardDialogService {
 }
 
 ```
-

--- a/apps/web/public/installation/manual/dropdown.md
+++ b/apps/web/public/installation/manual/dropdown.md
@@ -1,4 +1,8 @@
+
+
 ```angular-ts title="dropdown.component.ts" copyButton showLineNumbers
+import { Overlay, OverlayModule, OverlayPositionBuilder, OverlayRef } from '@angular/cdk/overlay';
+import { TemplatePortal } from '@angular/cdk/portal';
 import {
   ChangeDetectionStrategy,
   Component,
@@ -17,14 +21,11 @@ import {
   ViewContainerRef,
   ViewEncapsulation,
 } from '@angular/core';
-import { isPlatformBrowser } from '@angular/common';
-import { Overlay, OverlayModule, OverlayPositionBuilder, OverlayRef } from '@angular/cdk/overlay';
-import type { ClassValue } from 'clsx';
-import { TemplatePortal } from '@angular/cdk/portal';
-
 import { mergeClasses, transform } from '../../shared/utils/utils';
 import { dropdownContentVariants } from './dropdown.variants';
 
+import type { ClassValue } from 'clsx';
+import { isPlatformBrowser } from '@angular/common';
 @Component({
   selector: 'z-dropdown-menu',
   exportAs: 'zDropdownMenu',
@@ -282,6 +283,8 @@ export class ZardDropdownMenuComponent implements OnInit, OnDestroy {
 
 ```
 
+
+
 ```angular-ts title="dropdown.variants.ts" copyButton showLineNumbers
 import { cva, VariantProps } from 'class-variance-authority';
 
@@ -325,6 +328,8 @@ export type ZardDropdownItemVariants = VariantProps<typeof dropdownItemVariants>
 export type ZardDropdownLabelVariants = VariantProps<typeof dropdownLabelVariants>;
 
 ```
+
+
 
 ```angular-ts title="dropdown-item.component.ts" copyButton showLineNumbers
 import type { ClassValue } from 'clsx';
@@ -386,6 +391,8 @@ export class ZardDropdownMenuItemComponent {
 
 ```
 
+
+
 ```angular-ts title="dropdown-label.component.ts" copyButton showLineNumbers
 import type { ClassValue } from 'clsx';
 
@@ -421,6 +428,8 @@ export class ZardDropdownMenuLabelComponent {
 
 ```
 
+
+
 ```angular-ts title="dropdown-menu-content.component.ts" copyButton showLineNumbers
 import type { ClassValue } from 'clsx';
 
@@ -452,6 +461,8 @@ export class ZardDropdownMenuContentComponent {
 
 ```
 
+
+
 ```angular-ts title="dropdown-shortcut.component.ts" copyButton showLineNumbers
 import type { ClassValue } from 'clsx';
 
@@ -477,6 +488,8 @@ export class ZardDropdownMenuShortcutComponent {
 }
 
 ```
+
+
 
 ```angular-ts title="dropdown-trigger.directive.ts" copyButton showLineNumbers
 import { Directive, ElementRef, HostListener, inject, input, OnInit, ViewContainerRef } from '@angular/core';
@@ -583,6 +596,8 @@ export class ZardDropdownDirective implements OnInit {
 
 ```
 
+
+
 ```angular-ts title="dropdown.module.ts" copyButton showLineNumbers
 import { OverlayModule } from '@angular/cdk/overlay';
 import { NgModule } from '@angular/core';
@@ -610,6 +625,8 @@ const DROPDOWN_COMPONENTS = [
 export class ZardDropdownModule {}
 
 ```
+
+
 
 ```angular-ts title="dropdown.service.ts" copyButton showLineNumbers
 import { Overlay, OverlayPositionBuilder, OverlayRef } from '@angular/cdk/overlay';
@@ -817,3 +834,4 @@ export class ZardDropdownService {
 }
 
 ```
+

--- a/apps/web/public/installation/manual/menu.md
+++ b/apps/web/public/installation/manual/menu.md
@@ -1,3 +1,5 @@
+
+
 ```angular-ts title="menu.directive.ts" copyButton showLineNumbers
 import { BooleanInput } from '@angular/cdk/coercion';
 import { CdkMenuTrigger } from '@angular/cdk/menu';
@@ -171,6 +173,8 @@ export class ZardMenuDirective implements OnInit, OnDestroy {
 
 ```
 
+
+
 ```angular-ts title="menu.variants.ts" copyButton showLineNumbers
 import { cva, VariantProps } from 'class-variance-authority';
 
@@ -198,6 +202,8 @@ export type ZardMenuItemVariants = VariantProps<typeof menuItemVariants>;
 
 ```
 
+
+
 ```angular-ts title="menu-content.directive.ts" copyButton showLineNumbers
 import type { ClassValue } from 'clsx';
 
@@ -222,6 +228,8 @@ export class ZardMenuContentDirective {
 }
 
 ```
+
+
 
 ```angular-ts title="menu-item.directive.ts" copyButton showLineNumbers
 import type { ClassValue } from 'clsx';
@@ -312,6 +320,8 @@ export class ZardMenuItemDirective {
 
 ```
 
+
+
 ```angular-ts title="menu-manager.service.ts" copyButton showLineNumbers
 import { Injectable } from '@angular/core';
 
@@ -346,6 +356,8 @@ export class ZardMenuManagerService {
 
 ```
 
+
+
 ```angular-ts title="menu.module.ts" copyButton showLineNumbers
 import { NgModule } from '@angular/core';
 
@@ -362,3 +374,4 @@ const MENU_COMPONENTS = [ZardMenuContentDirective, ZardMenuItemDirective, ZardMe
 export class ZardMenuModule {}
 
 ```
+

--- a/apps/web/public/installation/manual/segmented.md
+++ b/apps/web/public/installation/manual/segmented.md
@@ -1,23 +1,13 @@
-```angular-ts title="segmented.component.ts" copyButton showLineNumbers
-import {
-  AfterContentInit,
-  ChangeDetectionStrategy,
-  Component,
-  computed,
-  contentChildren,
-  effect,
-  forwardRef,
-  input,
-  OnInit,
-  output,
-  signal,
-  ViewEncapsulation,
-} from '@angular/core';
-import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
-import type { ClassValue } from 'clsx';
 
-import { segmentedItemVariants, segmentedVariants, ZardSegmentedVariants } from './segmented.variants';
+
+```angular-ts title="segmented.component.ts" copyButton showLineNumbers
+import { ChangeDetectionStrategy, Component, computed, contentChildren, effect, forwardRef, input, OnInit, output, signal, ViewEncapsulation } from '@angular/core';
+import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+
 import { mergeClasses } from '../../shared/utils/utils';
+import { segmentedItemVariants, segmentedVariants, ZardSegmentedVariants } from './segmented.variants';
+
+import type { ClassValue } from 'clsx';
 
 export interface SegmentedOption {
   value: string;
@@ -170,6 +160,8 @@ export class ZardSegmentedComponent implements ControlValueAccessor, OnInit {
 
 ```
 
+
+
 ```angular-ts title="segmented.variants.ts" copyButton showLineNumbers
 import { cva, VariantProps } from 'class-variance-authority';
 
@@ -211,3 +203,4 @@ export type ZardSegmentedVariants = VariantProps<typeof segmentedVariants>;
 export type ZardSegmentedItemVariants = VariantProps<typeof segmentedItemVariants>;
 
 ```
+

--- a/apps/web/public/installation/manual/slider.md
+++ b/apps/web/public/installation/manual/slider.md
@@ -1,33 +1,37 @@
+
+
 ```angular-ts title="slider.component.ts" copyButton showLineNumbers
+import { fromEvent, map, Subject, switchMap, takeUntil, tap } from 'rxjs';
+
+import { DOCUMENT } from '@angular/common';
 import {
+  AfterViewInit,
+  booleanAttribute,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
+  computed,
   ElementRef,
+  forwardRef,
   inject,
   input,
+  linkedSignal,
+  numberAttribute,
+  OnChanges,
+  OnDestroy,
   output,
   signal,
+  SimpleChanges,
   viewChild,
   ViewEncapsulation,
-  numberAttribute,
-  booleanAttribute,
-  forwardRef,
-  AfterViewInit,
-  computed,
-  linkedSignal,
-  SimpleChanges,
-  OnDestroy,
-  OnChanges,
 } from '@angular/core';
-import { fromEvent, map, Subject, switchMap, takeUntil, tap } from 'rxjs';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
-import type { ClassValue } from 'clsx';
-import { DOCUMENT } from '@angular/common';
 
-import { sliderOrientationVariants, sliderRangeVariants, sliderThumbVariants, sliderTrackVariants, sliderVariants } from './slider.variants';
-import { clamp, roundToStep, convertValueToPercentage } from '../../shared/utils/number';
+import { clamp, convertValueToPercentage, roundToStep } from '../../shared/utils/number';
 import { mergeClasses } from '../../shared/utils/utils';
+import { sliderOrientationVariants, sliderRangeVariants, sliderThumbVariants, sliderTrackVariants, sliderVariants } from './slider.variants';
+
+import type { ClassValue } from 'clsx';
 
 type OnTouchedType = () => void;
 type OnChangeType = (value: number) => void;
@@ -389,6 +393,8 @@ export class ZardSliderComponent implements ControlValueAccessor, AfterViewInit,
 
 ```
 
+
+
 ```angular-ts title="slider.variants.ts" copyButton showLineNumbers
 import { cva, type VariantProps } from 'class-variance-authority';
 
@@ -466,3 +472,4 @@ export const sliderOrientationVariants = cva('absolute', {
 export type SliderOrientationVariants = VariantProps<typeof sliderOrientationVariants>;
 
 ```
+

--- a/libs/zard/src/lib/components/calendar/calendar.component.ts
+++ b/libs/zard/src/lib/components/calendar/calendar.component.ts
@@ -1,13 +1,13 @@
 import { ChangeDetectionStrategy, Component, computed, ElementRef, input, linkedSignal, model, signal, viewChild, ViewEncapsulation } from '@angular/core';
 import { outputFromObservable, outputToObservable } from '@angular/core/rxjs-interop';
+import { filter } from 'rxjs';
 
 import { calendarDayButtonVariants, calendarDayVariants, calendarNavVariants, calendarVariants, calendarWeekdayVariants, ZardCalendarVariants } from './calendar.variants';
 import { ZardSelectItemComponent } from '../select/select-item.component';
 import { ZardSelectComponent } from '../select/select.component';
 import { ZardButtonComponent } from '../button/button.component';
-import type { ClassValue } from '../../shared/utils/utils';
+import type { ClassValue } from 'clsx';
 import { mergeClasses } from '../../shared/utils/utils';
-import { filter } from 'rxjs';
 
 export interface CalendarDay {
   date: Date;
@@ -52,16 +52,16 @@ export type { ZardCalendarVariants };
         <!-- Month and Year Selectors -->
         <div class="flex items-center space-x-2">
           <!-- Month Select -->
-          <z-select [size]="selectSize()" class="min-w-[120px]" [value]="currentMonthValue()" [label]="currentMonthName()" (selectionChange)="onMonthChange($event)">
+          <z-select [zSize]="selectSize()" class="min-w-[120px]" [zValue]="currentMonthValue()" [zLabel]="currentMonthName()" (zSelectionChange)="onMonthChange($event)">
             @for (month of months; track $index) {
-              <z-select-item [value]="$index.toString()">{{ month }}</z-select-item>
+              <z-select-item [zValue]="$index.toString()">{{ month }}</z-select-item>
             }
           </z-select>
 
           <!-- Year Select -->
-          <z-select [size]="selectSize()" class="min-w-[80px]" [value]="currentYearValue()" [label]="currentYearValue()" (selectionChange)="onYearChange($event)">
+          <z-select [zSize]="selectSize()" class="min-w-[80px]" [zValue]="currentYearValue()" [zLabel]="currentYearValue()" (zSelectionChange)="onYearChange($event)">
             @for (year of availableYears(); track year) {
-              <z-select-item [value]="year.toString()">{{ year }}</z-select-item>
+              <z-select-item [zValue]="year.toString()">{{ year }}</z-select-item>
             }
           </z-select>
         </div>

--- a/libs/zard/src/lib/components/calendar/demo/sizes.ts
+++ b/libs/zard/src/lib/components/calendar/demo/sizes.ts
@@ -1,8 +1,8 @@
 import { Component, computed, signal } from '@angular/core';
 
+import { ZardCalendarComponent, ZardCalendarVariants } from '../calendar.component';
 import { ZardSelectItemComponent } from '../../select/select-item.component';
 import { ZardSelectComponent } from '../../select/select.component';
-import { ZardCalendarComponent, ZardCalendarVariants } from '../calendar.component';
 
 @Component({
   standalone: true,
@@ -11,10 +11,10 @@ import { ZardCalendarComponent, ZardCalendarVariants } from '../calendar.compone
     <div class="space-y-6">
       <div class="flex items-center gap-4">
         <label class="text-sm font-medium">Size:</label>
-        <z-select [value]="selectedSize() || 'default'" [label]="sizeLabel()" (selectionChange)="onSizeChange($event)" class="min-w-[120px]">
-          <z-select-item value="sm">Small</z-select-item>
-          <z-select-item value="default">Default</z-select-item>
-          <z-select-item value="lg">Large</z-select-item>
+        <z-select [zValue]="selectedSize() || 'default'" [zLabel]="sizeLabel()" (zSelectionChange)="onSizeChange($event)" class="min-w-[120px]">
+          <z-select-item zValue="sm">Small</z-select-item>
+          <z-select-item zValue="default">Default</z-select-item>
+          <z-select-item zValue="lg">Large</z-select-item>
         </z-select>
       </div>
 

--- a/libs/zard/src/lib/components/form/demo/complex.ts
+++ b/libs/zard/src/lib/components/form/demo/complex.ts
@@ -1,11 +1,11 @@
 import { ChangeDetectionStrategy, Component, inject, signal, ViewEncapsulation } from '@angular/core';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 
-import { ZardButtonComponent } from '../../button/button.component';
-import { ZardCheckboxComponent } from '../../checkbox/checkbox.component';
-import { ZardInputDirective } from '../../input/input.directive';
 import { ZardSelectItemComponent } from '../../select/select-item.component';
+import { ZardCheckboxComponent } from '../../checkbox/checkbox.component';
 import { ZardSelectComponent } from '../../select/select.component';
+import { ZardButtonComponent } from '../../button/button.component';
+import { ZardInputDirective } from '../../input/input.directive';
 import { ZardFormModule } from '../form.module';
 
 interface FormData {
@@ -67,7 +67,7 @@ interface FormData {
         <z-form-control [errorMessage]="isFieldInvalid('country') ? 'Please select a country' : ''">
           <z-select id="country" formControlName="country" placeholder="Select your country">
             @for (country of countries; track country.value) {
-              <z-select-item [value]="country.value">{{ country.label }}</z-select-item>
+              <z-select-item [zValue]="country.value">{{ country.label }}</z-select-item>
             }
           </z-select>
         </z-form-control>

--- a/libs/zard/src/lib/components/input-group/input-group.component.ts
+++ b/libs/zard/src/lib/components/input-group/input-group.component.ts
@@ -1,5 +1,5 @@
 import { booleanAttribute, ChangeDetectionStrategy, Component, computed, input, TemplateRef, ViewEncapsulation } from '@angular/core';
-import { ClassValue } from 'class-variance-authority/dist/types';
+import type { ClassValue } from 'clsx';
 
 import { inputGroupAddonVariants, inputGroupAffixVariants, inputGroupInputVariants, inputGroupVariants, ZardInputGroupVariants } from './input-group.variants';
 import { ZardStringTemplateOutletDirective } from '../core/directives/string-template-outlet/string-template-outlet.directive';

--- a/libs/zard/src/lib/components/select/demo/default.ts
+++ b/libs/zard/src/lib/components/select/demo/default.ts
@@ -8,12 +8,12 @@ import { ZardSelectComponent } from '../select.component';
   standalone: true,
   imports: [FormsModule, ZardSelectComponent, ZardSelectItemComponent],
   template: `
-    <z-select placeholder="Selecione uma fruta" [(ngModel)]="defaultValue">
-      <z-select-item value="apple">Apple</z-select-item>
-      <z-select-item value="banana">Banana</z-select-item>
-      <z-select-item value="blueberry">Blueberry</z-select-item>
-      <z-select-item value="grapes">Grapes</z-select-item>
-      <z-select-item value="pineapple" disabled>Pineapple</z-select-item>
+    <z-select zPlaceholder="Selecione uma fruta" [(ngModel)]="defaultValue">
+      <z-select-item zValue="apple">Apple</z-select-item>
+      <z-select-item zValue="banana">Banana</z-select-item>
+      <z-select-item zValue="blueberry">Blueberry</z-select-item>
+      <z-select-item zValue="grapes">Grapes</z-select-item>
+      <z-select-item zValue="pineapple" zDisabled>Pineapple</z-select-item>
     </z-select>
   `,
 })

--- a/libs/zard/src/lib/components/select/doc/api.md
+++ b/libs/zard/src/lib/components/select/doc/api.md
@@ -4,14 +4,14 @@
 
 > A customizable select component that allows single value selection.
 
-| Input           | Description                   | Type                        | Default                 |
-| --------------- | ----------------------------- | --------------------------- | ----------------------- |
-| `[class]`       | Custom CSS classes            | `string`                    | `''`                    |
-| `[zSize]`       | Sets the select size          | `'default' \| 'sm' \| 'lg'` | `'default'`             |
-| `[placeholder]` | Placeholder text              | `string`                    | `'Select an option...'` |
-| `[value]`       | Selected value                | `string`                    | `''`                    |
-| `[label]`       | Optional label for the select | `string`                    | `''`                    |
-| `[disabled]`    | Disables the select           | `boolean`                   | `false`                 |
+| Input            | Description                   | Type                        | Default                 |
+| ---------------- | ----------------------------- | --------------------------- | ----------------------- |
+| `[class]`        | Custom CSS classes            | `string`                    | `''`                    |
+| `[zSize]`        | Sets the select size          | `'default' \| 'sm' \| 'lg'` | `'default'`             |
+| `[zPlaceholder]` | Placeholder text              | `string`                    | `'Select an option...'` |
+| `[zValue]`       | Selected value                | `string`                    | `''`                    |
+| `[zLabel]`       | Optional label for the select | `string`                    | `''`                    |
+| `[zDisabled]`    | Disables the select           | `boolean`                   | `false`                 |
 
 | Output              | Description                             | Payload  |
 | ------------------- | --------------------------------------- | -------- |
@@ -21,8 +21,8 @@
 
 > Represents an individual item inside a `z-select` component.
 
-| Input        | Description                         | Type      | Default |
-| ------------ | ----------------------------------- | --------- | ------- |
-| `[class]`    | Custom CSS classes                  | `string`  | `''`    |
-| `[value]`    | The value associated with this item | `string`  | `''`    |
-| `[disabled]` | Disables selection for this item    | `boolean` | `false` |
+| Input         | Description                         | Type      | Default |
+| ------------- | ----------------------------------- | --------- | ------- |
+| `[class]`     | Custom CSS classes                  | `string`  | `''`    |
+| `[zValue]`    | The value associated with this item | `string`  | `''`    |
+| `[zDisabled]` | Disables selection for this item    | `boolean` | `false` |

--- a/libs/zard/src/lib/components/select/select-item.component.ts
+++ b/libs/zard/src/lib/components/select/select-item.component.ts
@@ -16,10 +16,10 @@ interface SelectHost {
   imports: [],
   host: {
     '[class]': 'classes()',
-    '[attr.value]': 'value()',
+    '[attr.value]': 'zValue()',
     role: 'option',
     tabindex: '-1',
-    '[attr.data-disabled]': 'disabled() ? "" : null',
+    '[attr.data-disabled]': 'zDisabled() ? "" : null',
     '[attr.data-selected]': 'isSelected() ? "" : null',
     '[attr.aria-selected]': 'isSelected()',
     '(click)': 'onClick()',
@@ -34,8 +34,8 @@ interface SelectHost {
   `,
 })
 export class ZardSelectItemComponent {
-  readonly value = input.required<string>();
-  readonly disabled = input(false, { transform });
+  readonly zValue = input.required<string>();
+  readonly zDisabled = input(false, { transform });
   readonly class = input<string>('');
 
   private select: SelectHost | null = null;
@@ -47,14 +47,14 @@ export class ZardSelectItemComponent {
 
   protected readonly classes = computed(() => mergeClasses(selectItemVariants(), this.class()));
 
-  protected readonly isSelected = computed(() => this.select?.selectedValue() === this.value());
+  protected readonly isSelected = computed(() => this.select?.selectedValue() === this.zValue());
 
   setSelectHost(selectHost: SelectHost) {
     this.select = selectHost;
   }
 
   onClick() {
-    if (this.disabled() || !this.select) return;
-    this.select.selectItem(this.value(), this.label());
+    if (this.zDisabled() || !this.select) return;
+    this.select.selectItem(this.zValue(), this.label());
   }
 }

--- a/libs/zard/src/lib/components/select/select.component.spec.ts
+++ b/libs/zard/src/lib/components/select/select.component.spec.ts
@@ -1,16 +1,16 @@
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Component, signal } from '@angular/core';
-import { FormControl, ReactiveFormsModule } from '@angular/forms';
 
-import { ZardSelectComponent } from './select.component';
 import { ZardSelectItemComponent } from './select-item.component';
+import { ZardSelectComponent } from './select.component';
 
 @Component({
   template: `
-    <z-select [value]="value()" [label]="label()" [placeholder]="placeholder()" [disabled]="disabled()">
-      <z-select-item value="option1">Option 1</z-select-item>
-      <z-select-item value="option2">Option 2</z-select-item>
-      <z-select-item value="option3">Option 3</z-select-item>
+    <z-select [zValue]="value()" [zLabel]="label()" [zPlaceholder]="placeholder()" [zDisabled]="disabled()">
+      <z-select-item zValue="option1">Option 1</z-select-item>
+      <z-select-item zValue="option2">Option 2</z-select-item>
+      <z-select-item zValue="option3">Option 3</z-select-item>
     </z-select>
   `,
   standalone: true,
@@ -26,9 +26,9 @@ class TestHostComponent {
 @Component({
   template: `
     <z-select [formControl]="control">
-      <z-select-item value="apple">Apple</z-select-item>
-      <z-select-item value="banana">Banana</z-select-item>
-      <z-select-item value="orange">Orange</z-select-item>
+      <z-select-item zValue="apple">Apple</z-select-item>
+      <z-select-item zValue="banana">Banana</z-select-item>
+      <z-select-item zValue="orange">Orange</z-select-item>
     </z-select>
   `,
   standalone: true,
@@ -64,8 +64,8 @@ describe('ZardSelectComponent', () => {
     it('should initialize with default values', () => {
       expect(component.selectedValue()).toBe('');
       expect(component.selectedLabel()).toBe('');
-      expect(component.placeholder()).toBe('Select an option...');
-      expect(component.disabled()).toBe(false);
+      expect(component.zPlaceholder()).toBe('Select an option...');
+      expect(component.zDisabled()).toBe(false);
     });
 
     describe('keyboard navigation', () => {

--- a/libs/zard/src/lib/components/select/select.variants.ts
+++ b/libs/zard/src/lib/components/select/select.variants.ts
@@ -4,14 +4,14 @@ export const selectTriggerVariants = cva(
   'flex w-full items-center justify-between gap-2 rounded-md border border-input bg-transparent px-3 py-2 whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none cursor-pointer focus-visible:ring-[3px] focus-visible:border-ring focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 data-[placeholder]:text-muted-foreground [&_svg:not([class*="text-"])]:text-muted-foreground dark:bg-input/30 dark:hover:bg-input/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*="size-"])]:size-4',
   {
     variants: {
-      size: {
+      zSize: {
         sm: 'h-8 text-xs',
         default: 'h-9 text-sm',
         lg: 'h-10 text-base',
       },
     },
     defaultVariants: {
-      size: 'default',
+      zSize: 'default',
     },
   },
 );


### PR DESCRIPTION
## What was done? 📝  
- Standardized inputs and outputs for the Select component using the z prefix.
- The Select documentation has been corrected and completed by adding missing parts.

## Screenshots or GIFs 📸  
<img width="907" height="859" alt="z-select-doc" src="https://github.com/user-attachments/assets/1ea66c7e-1753-4172-a30c-a998c9cc9301" />

## Link to Issue 🔗  
#202

## Type of change 🏗  
- [ ] New feature (non-breaking change that adds functionality)  
- [ ] Bug fix (non-breaking change that fixes an issue)  
- [x] Refactor (non-breaking change that improves the code or technical debt)  
- [ ] Chore (none of the above, such as upgrading libraries)  

## Breaking change 🚨  
The public API of the `Select` component has changed:  
- `size` → `zSize`  
- `placeholder` → `zPlaceholder`  
- `value` → `zValue`  
- `label` → `zLabel`  
- `disabled` → `zDisabled`  
- `selectionChange` → `zSelectionChange`  

## Checklist 🧐  
- [x] Tested on Chrome  
- [ ] Tested on Safari  
- [x] Tested Responsiveness  
- [x] No errors in the console  
