### PR TITLE
fix(button): clarify button click behavior with active scale animation

### DIFF
--- a/libs/zard/src/lib/components/button/button.component.ts
+++ b/libs/zard/src/lib/components/button/button.component.ts
@@ -35,6 +35,15 @@ export class ZardButtonComponent {
   readonly zLoading = input(false, { transform });
 
   protected readonly classes = computed(() =>
-    mergeClasses(buttonVariants({ zType: this.zType(), zSize: this.zSize(), zShape: this.zShape(), zFull: this.zFull(), zLoading: this.zLoading() }), this.class()),
+    mergeClasses(
+      buttonVariants({
+        zType: this.zType(),
+        zSize: this.zSize(),
+        zShape: this.zShape(),
+        zFull: this.zFull(),
+        zLoading: this.zLoading(),
+      }),
+      this.class(),
+    ),
   );
 }

--- a/libs/zard/src/lib/components/button/button.variants.ts
+++ b/libs/zard/src/lib/components/button/button.variants.ts
@@ -1,7 +1,7 @@
 import { cva, VariantProps } from 'class-variance-authority';
 
 export const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "cursor-pointer inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all active:scale-95 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   {
     variants: {
       zType: {


### PR DESCRIPTION
## What was done? 📝  
Improved the user feedback on button interactions by adding the Tailwind class `active:scale-95`, which provides a subtle scaling animation when the user clicks. This enhances the perceived responsiveness of the component and clarifies its behavior, especially for users unfamiliar with the button states.  

## Screenshots or GIFs 📸  
| Figma | Implementation |
|-------|----------------|
| N/A   | https://github.com/user-attachments/assets/69c4d1b8-1c5f-42dd-b63e-b66ed2d6816e |

## Link to Issue 🔗  
Closes #208

## Type of change 🏗  
- [x] Bug fix (non-breaking change that fixes an issue)  
- [ ] New feature  
- [ ] Refactor  
- [ ] Chore  

## Breaking change 🚨  
No breaking changes.

## Checklist 🧐  
- [x] Tested on Chrome  
- [x] Tested on Safari  
- [x] Tested Responsiveness  
- [x] No errors in the console  

