### PR TITLE
wip: keep popover open on scroll

### DIFF
--- a/apps/web/public/installation/manual/popover.md
+++ b/apps/web/public/installation/manual/popover.md
@@ -3,7 +3,7 @@
 ```angular-ts title="popover.component.ts" copyButton showLineNumbers
 import { Subject } from 'rxjs';
 
-import { ConnectedPosition, Overlay, OverlayPositionBuilder, OverlayRef } from '@angular/cdk/overlay';
+import { ConnectedPosition, createOverlayRef, Overlay, OverlayContainer, OverlayPositionBuilder, OverlayRef } from '@angular/cdk/overlay';
 import { TemplatePortal } from '@angular/cdk/portal';
 
 import {
@@ -14,6 +14,8 @@ import {
   effect,
   ElementRef,
   inject,
+  Injectable,
+  Injector,
   input,
   OnDestroy,
   OnInit,
@@ -65,9 +67,18 @@ const POPOVER_POSITIONS_MAP = {
   },
 } as const;
 
+@Injectable({ providedIn: 'root' })
+class CustomOverlayContainer extends OverlayContainer {
+  protected override _createContainer() {
+    super._createContainer();
+    this._containerElement.classList.add('z-10!');
+  }
+}
+
 @Directive({
   selector: '[zPopover]',
   exportAs: 'zPopover',
+  providers: [{ provide: OverlayContainer, useExisting: CustomOverlayContainer }],
   standalone: true,
 })
 export class ZardPopoverDirective implements OnInit, OnDestroy {
@@ -77,6 +88,7 @@ export class ZardPopoverDirective implements OnInit, OnDestroy {
   private readonly elementRef = inject(ElementRef);
   private readonly renderer = inject(Renderer2);
   private readonly viewContainerRef = inject(ViewContainerRef);
+  private readonly injector = inject(Injector);
 
   private overlayRef?: OverlayRef;
   private documentClickListenerRef?: () => void;
@@ -190,10 +202,10 @@ export class ZardPopoverDirective implements OnInit, OnDestroy {
       .withFlexibleDimensions(true)
       .withViewportMargin(8);
 
-    this.overlayRef = this.overlay.create({
+    this.overlayRef = createOverlayRef(this.injector, {
       positionStrategy,
       hasBackdrop: false,
-      scrollStrategy: this.overlay.scrollStrategies.close(),
+      scrollStrategy: this.overlay.scrollStrategies.reposition(),
     });
   }
 


### PR DESCRIPTION
## What was done? 📝

- Keeps the popover open while scrolling
- WIP: Allows specifying z-index

Note: This needs at least Angular 20 (#183), since `@angular/cdk` doesn't expose `createOverlayRef` before that.

## Screenshots or GIFs 📸
|-----Figma-----|
|-----Implementation-----|

## Link to Issue 🔗
#210 

## Type of change 🏗
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Refactor (non-breaking change that improves the code or technical debt)
- [ ] Chore (none of the above, such as upgrading libraries)

## Breaking change 🚨
<!-- describe here the breaking changes -->

## Checklist 🧐
- [ ] Tested on Chrome
- [ ] Tested on Safari
- [ ] Tested Responsiveness
- [ ] No errors in the console
