### PR TITLE
🐛 fix(input-group): correct ClassValue import path

### DIFF
--- a/apps/web/public/installation/manual/input-group.md
+++ b/apps/web/public/installation/manual/input-group.md
@@ -2,7 +2,7 @@
 
 ```angular-ts title="input-group.component.ts" copyButton showLineNumbers
 import { booleanAttribute, ChangeDetectionStrategy, Component, computed, input, TemplateRef, ViewEncapsulation } from '@angular/core';
-import { ClassValue } from 'class-variance-authority/dist/types';
+import type { ClassValue } from 'clsx';
 
 import { inputGroupAddonVariants, inputGroupAffixVariants, inputGroupInputVariants, inputGroupVariants, ZardInputGroupVariants } from './input-group.variants';
 import { ZardStringTemplateOutletDirective } from '../core/directives/string-template-outlet/string-template-outlet.directive';

--- a/libs/zard/src/lib/components/input-group/input-group.component.ts
+++ b/libs/zard/src/lib/components/input-group/input-group.component.ts
@@ -1,9 +1,9 @@
 import { booleanAttribute, ChangeDetectionStrategy, Component, computed, input, TemplateRef, ViewEncapsulation } from '@angular/core';
-import { ClassValue } from 'class-variance-authority/dist/types';
+import type { ClassValue } from 'clsx';
 
-import { inputGroupAddonVariants, inputGroupAffixVariants, inputGroupInputVariants, inputGroupVariants, ZardInputGroupVariants } from './input-group.variants';
-import { ZardStringTemplateOutletDirective } from '../core/directives/string-template-outlet/string-template-outlet.directive';
 import { generateId, mergeClasses } from '../../shared/utils/utils';
+import { ZardStringTemplateOutletDirective } from '../core/directives/string-template-outlet/string-template-outlet.directive';
+import { inputGroupAddonVariants, inputGroupAffixVariants, inputGroupInputVariants, inputGroupVariants, ZardInputGroupVariants } from './input-group.variants';
 
 @Component({
   selector: 'z-input-group',


### PR DESCRIPTION
## What was done? 📝

Fixed the import path for `ClassValue` type from `class-variance-authority` in the input-group component. Changed from using the dist/types path to the main package export which resolves the TypeScript compilation error TS2307 that was preventing `npm start` from working

**Changes made:**
- Updated import in `libs/zard/src/lib/components/input-group/input-group.component.ts` & `apps/web/public/installation/manual/input-group.md`
- Changed from `import { ClassValue } from 'class-variance-authority/dist/types';`
- To `import type { ClassValue } from 'clsx';`


## Screenshots or GIFs 📸

N/A - This is a build-time fix that resolves import errors.

## Link to Issue 🔗

Closes #222

## Type of change 🏗

- [ ] New feature (non-breaking change that adds functionality)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Refactor (non-breaking change that improves the code or technical debt)
- [ ] Chore (none of the above, such as upgrading libraries)

## Breaking change 🚨

No breaking changes - this is a simple import path correction that maintains the same functionality

## Checklist 🧐

- [ ] Tested on Chrome
- [ ] Tested on Safari  
- [ ] Tested Responsiveness
- [x] No errors in the console

**Additional verification:**
- [x] `npm start` runs successfully without errors
- [x] TypeScript compilation passes
- [x] No regression in component functionality