### PR TITLE
🐛 fix(registry): fix reference to non-existent dialog.component.html file

### DIFF
--- a/packages/cli/src/utils/registry.ts
+++ b/packages/cli/src/utils/registry.ts
@@ -107,10 +107,6 @@ export const registry: ComponentRegistry[] = [
         content: '',
       },
       {
-        name: 'dialog.component.html',
-        content: '',
-      },
-      {
         name: 'dialog.service.ts',
         content: '',
       },


### PR DESCRIPTION
## What was done? 📝
Fixed incorrect reference to `dialog.component.html` in `registry.ts`.  
The file was being required but does not exist in the dialog component directory.

## Screenshots or GIFs 📸
|-----Figma-----|
|  N/A  |
|-----Implementation-----|
|  N/A  |

## Link to Issue 🔗
Closes #226 

## Type of change 🏗
- [ ] New feature (non-breaking change that adds functionality)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Refactor (non-breaking change that improves the code or technical debt)
- [ ] Chore (none of the above, such as upgrading libraries)

## Breaking change 🚨
None

## Checklist 🧐
- [x] Tested on Chrome
- [ ] Tested on Safari
- [x] Tested Responsiveness
- [x] No errors in the console
