### PR TITLE
📝 docs(toast): add step to register the component

### DIFF
--- a/apps/web/public/installation/cli/register-toast.md
+++ b/apps/web/public/installation/cli/register-toast.md
@@ -1,0 +1,15 @@
+```angular-ts title="app.component.ts'" copyButton showLineNumbers
+import { Component } from '@angular/core';
+import { ZardToastComponent } from '@zard/toast';
+
+@Component({
+  selector: 'app-root',
+  standalone: true,
+  imports: [ZardToastComponent],
+  template: `
+    <router-outlet></router-outlet>
+    <z-toaster />
+  `,
+})
+export class AppComponent {}
+```

--- a/apps/web/public/installation/cli/register-toast.md
+++ b/apps/web/public/installation/cli/register-toast.md
@@ -1,11 +1,12 @@
 ```angular-ts title="app.component.ts'" copyButton showLineNumbers
 import { Component } from '@angular/core';
-import { ZardToastComponent } from '@zard/toast';
+import { RouterOutlet } from '@angular/router';
+import { ZardToastComponent } from '@shared/components/toast/toast.component';
 
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [ZardToastComponent],
+  imports: [RouterOutlet, ZardToastComponent],
   template: `
     <router-outlet></router-outlet>
     <z-toaster />

--- a/apps/web/public/installation/manual/register-toast.md
+++ b/apps/web/public/installation/manual/register-toast.md
@@ -1,0 +1,15 @@
+```angular-ts title="app.component.ts'" copyButton showLineNumbers
+import { Component } from '@angular/core';
+import { ZardToastComponent } from '@zard/toast';
+
+@Component({
+  selector: 'app-root',
+  standalone: true,
+  imports: [ZardToastComponent],
+  template: `
+    <router-outlet></router-outlet>
+    <z-toaster />
+  `,
+})
+export class AppComponent {}
+```

--- a/apps/web/public/installation/manual/register-toast.md
+++ b/apps/web/public/installation/manual/register-toast.md
@@ -1,11 +1,12 @@
 ```angular-ts title="app.component.ts'" copyButton showLineNumbers
 import { Component } from '@angular/core';
-import { ZardToastComponent } from '@zard/toast';
+import { RouterOutlet } from '@angular/router';
+import { ZardToastComponent } from '@shared/components/toast/toast.component';
 
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [ZardToastComponent],
+  imports: [RouterOutlet, ZardToastComponent],
   template: `
     <router-outlet></router-outlet>
     <z-toaster />

--- a/apps/web/src/app/shared/constants/install.constant.ts
+++ b/apps/web/src/app/shared/constants/install.constant.ts
@@ -1,6 +1,6 @@
 export interface Step {
   title: string;
-  subtitle: string;
+  subtitle?: string;
   url?: {
     text: string;
     href: string;

--- a/apps/web/src/app/shared/services/dynamic-installation.service.ts
+++ b/apps/web/src/app/shared/services/dynamic-installation.service.ts
@@ -25,6 +25,17 @@ export class DynamicInstallationService {
       },
     });
 
+    const hasExtraSteps = this.checkIfComponentHasRegisterStep(componentName);
+    if (hasExtraSteps) {
+      steps.push({
+        title: `Register ${componentName} to your project`,
+        file: {
+          path: `/installation/cli/register-${componentName}.md`,
+          lineNumber: true,
+        },
+      });
+    }
+
     return steps;
   }
 
@@ -54,10 +65,26 @@ export class DynamicInstallationService {
       expandable: true,
     });
 
+    const hasExtraSteps = this.checkIfComponentHasRegisterStep(componentName);
+    if (hasExtraSteps) {
+      steps.push({
+        title: `Register ${componentName}  to your project`,
+        file: {
+          path: `/installation/cli/register-${componentName}.md`,
+          lineNumber: true,
+        },
+      });
+    }
+
     return steps;
   }
 
   private checkIfComponentHasDependencies(componentName: string): boolean {
+    const componentsWithDeps = ['toast'];
+    return componentsWithDeps.includes(componentName);
+  }
+
+  private checkIfComponentHasRegisterStep(componentName: string): boolean {
     const componentsWithDeps = ['toast'];
     return componentsWithDeps.includes(componentName);
   }


### PR DESCRIPTION
## What was done? 📝
Updated the documentation for the Toast component, adding the step to import and register it in the root component.

## Screenshots or GIFs 📸
<img width="761" height="473" alt="register-toast" src="https://github.com/user-attachments/assets/fc024937-341b-4f03-b278-c4e2a4f94bce" />

## Link to Issue 🔗
Closes #225 

## Type of change 🏗
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Refactor (non-breaking change that improves the code or technical debt)
- [x] Chore (none of the above, such as upgrading libraries)

## Breaking change 🚨
<!-- describe here the breaking changes -->

## Checklist 🧐
- [x] Tested on Chrome
- [ ] Tested on Safari
- [x] Tested Responsiveness
- [x] No errors in the console
