### PR TITLE
🐛 fix: failing unit test for Sheet component

### DIFF
--- a/libs/zard/src/lib/components/sheet/sheet.component.spec.ts
+++ b/libs/zard/src/lib/components/sheet/sheet.component.spec.ts
@@ -1,6 +1,6 @@
+import { Component, inject, PLATFORM_ID, TemplateRef, ViewChild } from '@angular/core';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { Component, inject, PLATFORM_ID, TemplateRef, ViewChild } from '@angular/core';
 import { isPlatformBrowser } from '@angular/common';
 
 import { ZardButtonComponent } from '../button/button.component';
@@ -283,10 +283,8 @@ describe('ZardSheetComponent', () => {
         await fixture.whenStable();
 
         // Check that custom dimensions are applied via CSS variables
-        expect(sheetElement.style.width).toBe('var(--sheet-width)');
-        expect(sheetElement.style.height).toBe('var(--sheet-height)');
-        expect(sheetElement.style.getPropertyValue('--sheet-width')).toBe('500px');
-        expect(sheetElement.style.getPropertyValue('--sheet-height')).toBe('80vh');
+        expect(sheetElement.style.width).toBe('500px');
+        expect(sheetElement.style.height).toBe('80vh');
       }
     });
 


### PR DESCRIPTION
## What was done? 📝
Fix failing test in Sheet Component Spec file by checking for the actual width value and not the custom CSS variable's value since there is not custom CSS variable present.

## Screenshots or GIFs 📸
<img width="1384" height="723" alt="Screenshot 2025-10-09 014554" src="https://github.com/user-attachments/assets/9385c0b7-4bf2-4b47-8e53-db2302db452b" />


## Link to Issue 🔗
#242
#241 

## Type of change 🏗
- [ ] New feature (non-breaking change that adds functionality)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Refactor (non-breaking change that improves the code or technical debt)
- [ ] Chore (none of the above, such as upgrading libraries)

## Breaking change 🚨
None

## Checklist 🧐
- [x] Tested on Chrome
- [ ] Tested on Safari
- [ ] Tested Responsiveness
- [x] No errors in the console
