### PR TITLE
🐛 fix: popover to remain open when scrolling

### DIFF
--- a/libs/zard/src/lib/components/popover/popover.component.ts
+++ b/libs/zard/src/lib/components/popover/popover.component.ts
@@ -1,8 +1,3 @@
-import { Subject } from 'rxjs';
-
-import { ConnectedPosition, Overlay, OverlayPositionBuilder, OverlayRef } from '@angular/cdk/overlay';
-import { TemplatePortal } from '@angular/cdk/portal';
-
 import {
   ChangeDetectionStrategy,
   Component,
@@ -21,7 +16,10 @@ import {
   TemplateRef,
   ViewContainerRef,
 } from '@angular/core';
+import { ConnectedPosition, Overlay, OverlayPositionBuilder, OverlayRef } from '@angular/cdk/overlay';
+import { TemplatePortal } from '@angular/cdk/portal';
 import { isPlatformBrowser } from '@angular/common';
+import { Subject } from 'rxjs';
 
 import { mergeClasses } from '../../shared/utils/utils';
 import { popoverVariants } from './popover.variants';
@@ -187,14 +185,14 @@ export class ZardPopoverDirective implements OnInit, OnDestroy {
       const positionStrategy = this.overlayPositionBuilder
         .flexibleConnectedTo(this.nativeElement)
         .withPositions(this.getPositions())
-        .withPush(true)
-        .withFlexibleDimensions(true)
+        .withPush(false)
+        .withFlexibleDimensions(false)
         .withViewportMargin(8);
 
       this.overlayRef = this.overlay.create({
         positionStrategy,
         hasBackdrop: false,
-        scrollStrategy: this.overlay.scrollStrategies.close(),
+        scrollStrategy: this.overlay.scrollStrategies.reposition(),
       });
     }
   }


### PR DESCRIPTION
## What was done? 📝
Make the popover not close when scrolling. This also improves the combobox experience.

## Screenshots or GIFs 📸

https://github.com/user-attachments/assets/e7a15ba8-88d0-4396-9833-4fb16c897c2c


## Link to Issue 🔗
closes #210 

## Type of change 🏗
- [ ] New feature (non-breaking change that adds functionality)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Refactor (non-breaking change that improves the code or technical debt)
- [ ] Chore (none of the above, such as upgrading libraries)

## Breaking change 🚨
None

## Checklist 🧐
- [x] Tested on Chrome
- [ ] Tested on Safari
- [ ] Tested Responsiveness
- [x] No errors in the console
