### PR TITLE
docs(button): add link variant example

### DIFF
--- a/libs/zard/src/lib/components/button/demo/button.ts
+++ b/libs/zard/src/lib/components/button/demo/button.ts
@@ -7,6 +7,7 @@ import { ZardDemoButtonShapeComponent } from './shape';
 import { ZardDemoButtonGhostComponent } from './ghost';
 import { ZardDemoButtonSizeComponent } from './size';
 import { ZardDemoButtonFullComponent } from './full';
+import { ZardDemoButtonLinkComponent } from './link';
 
 export const BUTTON = {
   componentName: 'button',
@@ -31,6 +32,10 @@ export const BUTTON = {
     {
       name: 'ghost',
       component: ZardDemoButtonGhostComponent,
+    },
+    {
+      name: 'link',
+      component: ZardDemoButtonLinkComponent,
     },
     {
       name: 'size',


### PR DESCRIPTION
## Summary
Adds the missing link button variant example to the button component documentation.

## Changes
- Imported `ZardDemoButtonLinkComponent` in `button.ts`
- Added link variant to the examples array

## Details
The link button demo component (`link.ts`) already existed but was not registered in the main button demo export, so it wasn't showing up in the documentation.

This PR adds the import and registers it in the examples array, making the link variant visible on the button component page, matching the shadcn/ui documentation structure.

Fixes #260

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new link button variant example to the component demo.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->