### PR TITLE
🐛 fix(ZardAlertDialogComponent): Duplicate identifier 'ZardAlertDialogService'

### DIFF
--- a/libs/zard/src/lib/components/alert-dialog/alert-dialog.component.ts
+++ b/libs/zard/src/lib/components/alert-dialog/alert-dialog.component.ts
@@ -23,12 +23,10 @@ import type { ClassValue } from 'clsx';
 
 import { alertDialogVariants, type ZardAlertDialogVariants } from './alert-dialog.variants';
 import { ZardButtonComponent } from '../button/button.component';
+// The service is used in the NgModule providers below, not in the component class.
 import { ZardAlertDialogService } from './alert-dialog.service';
 import type { ZardAlertDialogRef } from './alert-dialog-ref';
 import { generateId, mergeClasses } from '../../shared/utils/utils';
-// The service is used in the NgModule providers below, not in the component class.
-
-import { ZardAlertDialogService } from './alert-dialog.service';
 
 const noopFun = () => void 0;
 


### PR DESCRIPTION
## What was done? 📝
removed duplicate import

## Screenshots or GIFs 📸
<img width="1122" height="343" alt="image" src="https://github.com/user-attachments/assets/68bc9040-21e0-443f-9952-b0151d9a8177" />

## Link to Issue 🔗
closes #293 

## Type of change 🏗
- [ ] New feature (non-breaking change that adds functionality)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Refactor (non-breaking change that improves the code or technical debt)
- [ ] Chore (none of the above, such as upgrading libraries)

## Breaking change 🚨
<!-- describe here the breaking changes -->

## Checklist 🧐
- [x] Tested on Chrome
- [ ] Tested on Safari
- [ ] Tested Responsiveness
- [x] No errors in the console


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated Alert Dialog API: `afterClosed` is now an observable property instead of a method, providing a simplified way to observe dialog completion events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->