### PR TITLE
📦 refactor: input group #288

### DIFF
--- a/apps/web/public/components/button/doc/api.md
+++ b/apps/web/public/components/button/doc/api.md
@@ -5,7 +5,7 @@
 | Property   | Description          | Type                                                              | Default   |
 | ---------- | -------------------- | ----------------------------------------------------------------- | --------- |
 | `zType`    | button type          | `default \| destructive \| outline \| secondary \| ghost \| link` | `default` |
-| `zSize`    | button size          | `default \| sm \| lg \|icon`                                      | `default` |
+| `zSize`    | button size          | `default \| sm \| lg`                                             | `default` |
 | `zShape`   | button shape         | `default \| circle \| square`                                     | `default` |
 | `zFull`    | button width 100%    | `boolean`                                                         | `false`   |
 | `zLoading` | button loading state | `boolean`                                                         | `false`   |

--- a/apps/web/public/components/input-group/demo/borderless.md
+++ b/apps/web/public/components/input-group/demo/borderless.md
@@ -1,24 +1,24 @@
 ```angular-ts showLineNumbers copyButton
-import { Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 
 import { ZardInputDirective } from '../../input/input.directive';
 import { ZardInputGroupComponent } from '../input-group.component';
 
 @Component({
   selector: 'z-demo-input-group-borderless',
-  standalone: true,
   imports: [ZardInputGroupComponent, ZardInputDirective],
+  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <div class="flex flex-col space-y-4">
-      <z-input-group zPrefix="$" zSuffix="USD" zBorderless>
+      <z-input-group zAddonBefore="$" zAddonAfter="USD" class="border-0">
         <input z-input placeholder="0.00" type="number" />
       </z-input-group>
 
-      <z-input-group zAddOnBefore="https://" zAddOnAfter=".com" zBorderless>
+      <z-input-group zAddonBefore="https://" zAddonAfter=".com" class="border-0">
         <input z-input placeholder="example" />
       </z-input-group>
 
-      <z-input-group zAddOnBefore="@" zBorderless>
+      <z-input-group zAddonBefore="@" class="border-0">
         <input z-input placeholder="username" />
       </z-input-group>
     </div>

--- a/apps/web/public/components/input-group/demo/default.md
+++ b/apps/web/public/components/input-group/demo/default.md
@@ -1,27 +1,76 @@
 ```angular-ts showLineNumbers copyButton
 import { Component } from '@angular/core';
 
+import { ZardButtonComponent } from '../../button/button.component';
+import { ZardDividerComponent } from '../../divider/divider.component';
+import { ZardDropdownModule } from '../../dropdown/dropdown.module';
+import { ZardIconComponent } from '../../icon/icon.component';
 import { ZardInputDirective } from '../../input/input.directive';
+import { ZardTooltipDirective } from '../../tooltip/tooltip';
 import { ZardInputGroupComponent } from '../input-group.component';
 
 @Component({
   selector: 'z-demo-input-group-default',
-  standalone: true,
-  imports: [ZardInputGroupComponent, ZardInputDirective],
+  imports: [
+    ZardButtonComponent,
+    ZardDropdownModule,
+    ZardIconComponent,
+    ZardInputDirective,
+    ZardInputGroupComponent,
+    ZardDividerComponent,
+    ZardTooltipDirective,
+  ],
   template: `
-    <div class="flex flex-col space-y-4">
-      <z-input-group zAddOnBefore="https://" zAddOnAfter=".com" class="mb-4">
-        <input z-input placeholder="example" />
+    <div class="flex w-[380px] flex-col space-y-4">
+      <z-input-group [zAddonBefore]="search" zAddonAfter="12 results" class="mb-4">
+        <input z-input placeholder="Search..." />
       </z-input-group>
 
-      <z-input-group zPrefix="$" zSuffix="USD" class="mb-4">
-        <input z-input placeholder="0.00" type="number" />
+      <z-input-group zAddonBefore="https://" [zAddonAfter]="info" class="mb-4">
+        <input z-input placeholder="example.com" />
       </z-input-group>
 
-      <z-input-group zAddOnBefore="@">
-        <input z-input placeholder="username" />
+      <z-input-group class="mb-4" [zAddonAfter]="areaAfter">
+        <textarea class="h-30 resize-none" z-input placeholder="Ask, Search or Chat..."></textarea>
+      </z-input-group>
+
+      <z-input-group [zAddonAfter]="check">
+        <input z-input placeholder="@zardui" />
       </z-input-group>
     </div>
+
+    <ng-template #search><z-icon zType="search" /></ng-template>
+
+    <ng-template #check>
+      <div class="bg-primary rounded-full p-0.5">
+        <z-icon zType="check" class="stroke-primary-foreground" zSize="sm" />
+      </div>
+    </ng-template>
+
+    <ng-template #info><z-icon zType="info" zTooltip="Element with tooltip" /></ng-template>
+
+    <ng-template #areaAfter>
+      <div class="flex w-full items-center justify-between">
+        <div class="flex items-center gap-1">
+          <button type="button" z-button zType="outline" zShape="circle" class="data-icon-only:size-6!">
+            <z-icon zType="plus" />
+          </button>
+          <button type="button" z-button zType="ghost" class="h-6" z-dropdown [zDropdownMenu]="menu">Auto</button>
+          <z-dropdown-menu-content #menu="zDropdownMenuContent" class="w-10">
+            <z-dropdown-menu-item> Auto </z-dropdown-menu-item>
+            <z-dropdown-menu-item> Agent </z-dropdown-menu-item>
+            <z-dropdown-menu-item> Manual </z-dropdown-menu-item>
+          </z-dropdown-menu-content>
+        </div>
+        <div class="flex h-auto items-center gap-0">
+          <span>52% used</span>
+          <z-divider zOrientation="vertical" class="h-4" />
+          <button type="button" z-button zType="outline" zShape="circle" class="data-icon-only:size-6!">
+            <z-icon zType="arrow-up" />
+          </button>
+        </div>
+      </div>
+    </ng-template>
   `,
 })
 export class ZardDemoInputGroupDefaultComponent {}

--- a/apps/web/public/components/input-group/demo/loading.md
+++ b/apps/web/public/components/input-group/demo/loading.md
@@ -1,0 +1,24 @@
+```angular-ts showLineNumbers copyButton
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+
+import { ZardIconComponent } from '../../icon/icon.component';
+import { ZardInputDirective } from '../../input/input.directive';
+import { ZardInputGroupComponent } from '../input-group.component';
+
+@Component({
+  selector: 'z-demo-input-group-loading',
+  imports: [ZardInputGroupComponent, ZardInputDirective, ZardIconComponent],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div class="flex flex-col space-y-4">
+      <z-input-group [zAddonBefore]="search" zLoading>
+        <input z-input type="text" placeholder="Search..." />
+      </z-input-group>
+    </div>
+
+    <ng-template #search><z-icon zType="search" /></ng-template>
+  `,
+})
+export class ZardDemoInputGroupLoadingComponent {}
+
+```

--- a/apps/web/public/components/input-group/demo/size.md
+++ b/apps/web/public/components/input-group/demo/size.md
@@ -1,26 +1,25 @@
 ```angular-ts showLineNumbers copyButton
-import { Component } from '@angular/core';
-import { FormsModule } from '@angular/forms';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 
 import { ZardInputDirective } from '../../input/input.directive';
 import { ZardInputGroupComponent } from '../input-group.component';
 
 @Component({
   selector: 'z-demo-input-group-size',
-  standalone: true,
-  imports: [ZardInputGroupComponent, ZardInputDirective, FormsModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [ZardInputGroupComponent, ZardInputDirective],
   template: `
     <div class="flex flex-col space-y-4">
-      <z-input-group zSize="sm" zAddOnBefore="@" zAddOnAfter=".com" class="mb-4">
-        <input z-input placeholder="Small" [(ngModel)]="smallValue" />
+      <z-input-group zSize="sm" zAddonBefore="https://" zAddonAfter=".com" class="mb-4">
+        <input z-input placeholder="Small" [(value)]="smallValue" />
       </z-input-group>
 
-      <z-input-group zSize="default" zAddOnBefore="@" zAddOnAfter=".com" class="mb-4">
-        <input z-input placeholder="Default" [(ngModel)]="defaultValue" />
+      <z-input-group zSize="default" zAddonBefore="https://" zAddonAfter=".com" class="mb-4">
+        <input z-input placeholder="Default" [(value)]="defaultValue" />
       </z-input-group>
 
-      <z-input-group zSize="lg" zAddOnBefore="@" zAddOnAfter=".com">
-        <input z-input placeholder="Large" [(ngModel)]="largeValue" />
+      <z-input-group zSize="lg" zAddonBefore="https://" zAddonAfter=".com">
+        <input z-input placeholder="Large" [(value)]="largeValue" />
       </z-input-group>
     </div>
   `,

--- a/apps/web/public/components/input-group/demo/text.md
+++ b/apps/web/public/components/input-group/demo/text.md
@@ -1,0 +1,39 @@
+```angular-ts showLineNumbers copyButton
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+
+import { ZardButtonComponent } from '../../button/button.component';
+import { ZardInputDirective } from '../../input/input.directive';
+import { ZardInputGroupComponent } from '../input-group.component';
+
+@Component({
+  selector: 'z-demo-input-group-text',
+  imports: [ZardInputGroupComponent, ZardInputDirective, ZardButtonComponent],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <z-input-group zAddonBefore="$" zAddonAfter="USD" class="mb-4">
+      <input z-input placeholder="0.00" type="number" />
+    </z-input-group>
+
+    <z-input-group zAddonBefore="https://" zAddonAfter=".com" class="mb-4">
+      <input z-input placeholder="example.com" />
+    </z-input-group>
+
+    <z-input-group zAddonAfter="@company.com" class="mb-4">
+      <input z-input placeholder="Enter your username" />
+    </z-input-group>
+
+    <z-input-group [zAddonAfter]="actions" class="mb-4">
+      <textarea z-input class="resize-none" placeholder="Enter your message"></textarea>
+    </z-input-group>
+
+    <ng-template #actions>
+      <div class="flex w-full items-center justify-between">
+        <span class="text-muted-foreground text-xs">120 characters left</span>
+        <button type="submit" z-button zSize="sm">Submit</button>
+      </div>
+    </ng-template>
+  `,
+})
+export class ZardDemoInputGroupTextComponent {}
+
+```

--- a/apps/web/public/components/input-group/doc/api.md
+++ b/apps/web/public/components/input-group/doc/api.md
@@ -4,20 +4,12 @@
 
 ### z-input-group
 
-| Input                   | Type                                | Default     | Description                                    |
-| ----------------------- | ----------------------------------- | ----------- | ---------------------------------------------- |
-| `zSize`                 | `'sm' \| 'default' \| 'lg'`         | `'default'` | Size of the input group and all its elements   |
-| `zDisabled`             | `boolean`                           | `false`     | Disable the entire input group                 |
-| `zBorderless`           | `boolean`                           | `false`     | Remove borders and background for a clean look |
-| `zAddOnBefore`          | `string \| TemplateRef<void>`       | `undefined` | Content to display before the input            |
-| `zAddOnAfter`           | `string \| TemplateRef<void>`       | `undefined` | Content to display after the input             |
-| `zPrefix`               | `string \| TemplateRef<void>`       | `undefined` | Prefix content inside the input (left)         |
-| `zSuffix`               | `string \| TemplateRef<void>`       | `undefined` | Suffix content inside the input (right)        |
-| `zAriaLabel`            | `string`                            | `undefined` | Accessibility label for the input group        |
-| `zAriaLabelledBy`       | `string`                            | `undefined` | ID of element that labels the input group      |
-| `zAriaDescribedBy`      | `string`                            | `undefined` | ID of element that describes the input group   |
-| `zAddOnBeforeAriaLabel` | `string`                            | `undefined` | Accessibility label for the before addon       |
-| `zAddOnAfterAriaLabel`  | `string`                            | `undefined` | Accessibility label for the after addon        |
-| `zPrefixAriaLabel`      | `string`                            | `undefined` | Accessibility label for the prefix             |
-| `zSuffixAriaLabel`      | `string`                            | `undefined` | Accessibility label for the suffix             |
-| `class`                 | `ClassValue`                        | `''`        | Additional CSS classes                         |
+| Input          | Type                          | Default     | Description                                  |
+| -------------- | ----------------------------- | ----------- | -------------------------------------------- |
+| `class`        | `ClassValue`                  | `''`        | Custom CSS classes                           |
+| `zAddonAlign`  | `'inline' \| 'block'`         | `inline`    | Addon alignment                              |
+| `zAddonAfter`  | `string \| TemplateRef<void>` | `''`        | Addon after input                            |
+| `zAddonBefore` | `string \| TemplateRef<void>` | `''`        | Addon before input                           |
+| `zDisabled`    | `boolean`                     | `false`     | Disable the entire input group               |
+| `zLoading`     | `boolean`                     | `false`     | Loading state with spinner                   |
+| `zSize`        | `'sm' \| 'default' \| 'lg'`   | `'default'` | Size of the input group and all its elements |

--- a/apps/web/public/components/input/doc/api.md
+++ b/apps/web/public/components/input/doc/api.md
@@ -6,8 +6,8 @@
 
 To get a customized input, just pass the following props to the directive.
 
-| Property        | Description          | Type                      | Default   |
-| --------------- | -------------------- | ------------------------- | --------- |
-| `[zSize]`       | input size           | `default\|small\|large`   | `default` |
-| `[zStatus]`     | input status         | `error\|warning\|success` | `null`    |
-| `[zBorderless]` | input without border | `boolean`                 | `false`   |
+| Property        | Description          | Type                          | Default   |
+| --------------- | -------------------- | ----------------------------- | --------- |
+| `[zSize]`       | input size           | `default \| sm \| lg`         | `default` |
+| `[zStatus]`     | input status         | `error \| warning \| success` | `null`    |
+| `[zBorderless]` | input without border | `boolean`                     | `false`   |

--- a/apps/web/public/installation/manual/input-group.md
+++ b/apps/web/public/installation/manual/input-group.md
@@ -1,142 +1,141 @@
 
 
 ```angular-ts title="input-group.component.ts" expandable="true" expandableTitle="Expand" copyButton showLineNumbers
-import { booleanAttribute, ChangeDetectionStrategy, Component, computed, input, type TemplateRef, ViewEncapsulation } from '@angular/core';
+import {
+  booleanAttribute,
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  contentChild,
+  effect,
+  input,
+  type TemplateRef,
+  ViewEncapsulation,
+} from '@angular/core';
 
 import type { ClassValue } from 'clsx';
 
-import { inputGroupAddonVariants, inputGroupAffixVariants, inputGroupInputVariants, inputGroupVariants, type ZardInputGroupVariants } from './input-group.variants';
+import {
+  inputGroupAddonVariants,
+  inputGroupInputVariants,
+  inputGroupVariants,
+  type ZardInputGroupAddonAlignVariants,
+  type ZardInputGroupAddonPositionVariants,
+} from './input-group.variants';
 import { generateId, mergeClasses } from '../../shared/utils/utils';
-import { ZardStringTemplateOutletDirective } from '../core/directives/string-template-outlet/string-template-outlet.directive';
+import {
+  isTemplateRef,
+  ZardStringTemplateOutletDirective,
+} from '../core/directives/string-template-outlet/string-template-outlet.directive';
+import { ZardInputDirective } from '../input/input.directive';
+import type { ZardInputSizeVariants } from '../input/input.variants';
+import { ZardLoaderComponent } from '../loader/loader.component';
 
 @Component({
   selector: 'z-input-group',
-  exportAs: 'zInputGroup',
-  standalone: true,
-  imports: [ZardStringTemplateOutletDirective],
+  imports: [ZardStringTemplateOutletDirective, ZardLoaderComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   template: `
-    <div
-      [class]="wrapperClasses()"
-      [attr.role]="'group'"
-      [attr.aria-label]="zAriaLabel()"
-      [attr.aria-labelledby]="zAriaLabelledBy()"
-      [attr.aria-describedby]="zAriaDescribedBy()"
-      [attr.aria-disabled]="zDisabled()"
-      [attr.data-disabled]="zDisabled()"
-    >
-      @if (zAddOnBefore()) {
-        <div [class]="addonBeforeClasses()" [id]="addonBeforeId()" [attr.aria-label]="zAddOnBeforeAriaLabel()" [attr.aria-disabled]="zDisabled()">
-          <ng-container *zStringTemplateOutlet="zAddOnBefore()">{{ zAddOnBefore() }}</ng-container>
-        </div>
-      }
-
-      <div [class]="inputWrapperClasses()">
-        @if (zPrefix()) {
-          <div [class]="prefixClasses()" [id]="prefixId()" [attr.aria-label]="zPrefixAriaLabel()" [attr.aria-hidden]="true">
-            <ng-container *zStringTemplateOutlet="zPrefix()">{{ zPrefix() }}</ng-container>
-          </div>
-        }
-
-        <ng-content select="input[z-input], textarea[z-input]"></ng-content>
-
-        @if (zSuffix()) {
-          <div [class]="suffixClasses()" [id]="suffixId()" [attr.aria-label]="zSuffixAriaLabel()" [attr.aria-hidden]="true">
-            <ng-container *zStringTemplateOutlet="zSuffix()">{{ zSuffix() }}</ng-container>
-          </div>
-        }
+    @let addonBefore = zAddonBefore();
+    @if (addonBefore) {
+      <div [class]="addonBeforeClasses()" [id]="addonBeforeId" [attr.aria-disabled]="zDisabled() || zLoading()">
+        <ng-container *zStringTemplateOutlet="addonBefore">{{ addonBefore }}</ng-container>
       </div>
+    }
 
-      @if (zAddOnAfter()) {
-        <div [class]="addonAfterClasses()" [id]="addonAfterId()" [attr.aria-label]="zAddOnAfterAriaLabel()" [attr.aria-disabled]="zDisabled()">
-          <ng-container *zStringTemplateOutlet="zAddOnAfter()">{{ zAddOnAfter() }}</ng-container>
-        </div>
+    <div [class]="inputWrapperClasses()">
+      <ng-content select="input[z-input], textarea[z-input]" />
+
+      @if (zLoading()) {
+        <z-loader zSize="sm" />
       }
     </div>
+
+    @let addonAfter = zAddonAfter();
+    @if (addonAfter) {
+      <div [class]="addonAfterClasses()" [id]="addonAfterId" [attr.aria-disabled]="zDisabled() || zLoading()">
+        <ng-container *zStringTemplateOutlet="addonAfter">{{ addonAfter }}</ng-container>
+      </div>
+    }
   `,
   host: {
     '[class]': 'classes()',
+    '[attr.aria-disabled]': 'zDisabled() || zLoading()',
+    '[attr.data-disabled]': 'zDisabled() || zLoading()',
+    '[attr.aria-busy]': 'zLoading()',
+    'data-slot': 'input-group',
+    role: 'group',
   },
 })
 export class ZardInputGroupComponent {
-  readonly zSize = input<ZardInputGroupVariants['zSize']>('default');
-  readonly zAddOnBefore = input<string | TemplateRef<void>>();
-  readonly zAddOnAfter = input<string | TemplateRef<void>>();
-  readonly zPrefix = input<string | TemplateRef<void>>();
-  readonly zSuffix = input<string | TemplateRef<void>>();
-  readonly zDisabled = input(false, { transform: booleanAttribute });
-  readonly zBorderless = input(false, { transform: booleanAttribute });
-  readonly zAriaLabel = input<string>();
-  readonly zAriaLabelledBy = input<string>();
-  readonly zAriaDescribedBy = input<string>();
-  readonly zAddOnBeforeAriaLabel = input<string>();
-  readonly zAddOnAfterAriaLabel = input<string>();
-  readonly zPrefixAriaLabel = input<string>();
-  readonly zSuffixAriaLabel = input<string>();
   readonly class = input<ClassValue>('');
+  readonly zAddonAfter = input<string | TemplateRef<void>>('');
+  readonly zAddonAlign = input<ZardInputGroupAddonAlignVariants>('inline');
+  readonly zAddonBefore = input<string | TemplateRef<void>>('');
+  readonly zDisabled = input(false, { transform: booleanAttribute });
+  readonly zLoading = input(false, { transform: booleanAttribute });
+  readonly zSize = input<ZardInputSizeVariants>('default');
 
-  protected readonly classes = computed(() => mergeClasses('w-full', this.class()));
-
+  private readonly contentInput = contentChild<ZardInputDirective>(ZardInputDirective);
   private readonly uniqueId = generateId('input-group');
-  protected readonly addonBeforeId = computed(() => `${this.uniqueId}-addon-before`);
-  protected readonly addonAfterId = computed(() => `${this.uniqueId}-addon-after`);
-  protected readonly prefixId = computed(() => `${this.uniqueId}-prefix`);
-  protected readonly suffixId = computed(() => `${this.uniqueId}-suffix`);
 
-  protected readonly wrapperClasses = computed(() =>
-    inputGroupVariants({
-      zSize: this.zSize(),
-      zDisabled: this.zDisabled(),
-    }),
+  protected readonly addonBeforeId = `${this.uniqueId}-addon-before`;
+  protected readonly addonAfterId = `${this.uniqueId}-addon-after`;
+  protected readonly isAddonBeforeTemplate = computed(() => isTemplateRef(this.zAddonBefore()));
+  protected readonly classes = computed(() =>
+    mergeClasses(
+      'w-full',
+      inputGroupVariants({
+        zSize: this.zSize(),
+        zDisabled: this.zDisabled() || this.zLoading(),
+      }),
+      this.class(),
+    ),
   );
 
-  protected readonly addonBeforeClasses = computed(() =>
-    inputGroupAddonVariants({
-      zSize: this.zSize(),
-      zPosition: 'before',
-      zDisabled: this.zDisabled(),
-      zBorderless: this.zBorderless(),
-    }),
-  );
-
-  protected readonly addonAfterClasses = computed(() =>
-    inputGroupAddonVariants({
-      zSize: this.zSize(),
-      zPosition: 'after',
-      zDisabled: this.zDisabled(),
-      zBorderless: this.zBorderless(),
-    }),
-  );
-
-  protected readonly prefixClasses = computed(() =>
-    inputGroupAffixVariants({
-      zSize: this.zSize(),
-      zPosition: 'prefix',
-    }),
-  );
-
-  protected readonly suffixClasses = computed(() =>
-    inputGroupAffixVariants({
-      zSize: this.zSize(),
-      zPosition: 'suffix',
-    }),
-  );
-
-  protected readonly inputWrapperClasses = computed(() => {
-    return mergeClasses(
+  protected readonly inputWrapperClasses = computed(() =>
+    mergeClasses(
       inputGroupInputVariants({
         zSize: this.zSize(),
-        zHasPrefix: Boolean(this.zPrefix()),
-        zHasSuffix: Boolean(this.zSuffix()),
-        zHasAddonBefore: Boolean(this.zAddOnBefore()),
-        zHasAddonAfter: Boolean(this.zAddOnAfter()),
-        zDisabled: this.zDisabled(),
-        zBorderless: this.zBorderless(),
+        zHasAddonBefore: Boolean(this.zAddonBefore()),
+        zHasAddonAfter: Boolean(this.zAddonAfter()),
+        zDisabled: this.zDisabled() || this.zLoading(),
       }),
       'relative',
+    ),
+  );
+
+  protected readonly addonAfterClasses = computed(() => this.addonClasses('after'));
+  protected readonly addonBeforeClasses = computed(() =>
+    mergeClasses(this.addonClasses('before'), this.isAddonBeforeTemplate() ? 'pr-0.5' : ''),
+  );
+
+  constructor() {
+    effect(() => {
+      const contentInput = this.contentInput();
+      const disabled = this.zDisabled();
+      const size = this.zSize();
+
+      if (size) {
+        contentInput?.size.set(size);
+      }
+      contentInput?.disable(disabled);
+      contentInput?.setDataSlot('input-group-control');
+    });
+  }
+
+  private addonClasses(position: ZardInputGroupAddonPositionVariants): string {
+    return mergeClasses(
+      inputGroupAddonVariants({
+        zAlign: this.zAddonAlign(),
+        zDisabled: this.zDisabled() || this.zLoading(),
+        zPosition: position,
+        zSize: this.zSize(),
+        zType: this.contentInput()?.getType() ?? 'default',
+      }),
     );
-  });
+  }
 }
 
 ```
@@ -146,14 +145,26 @@ export class ZardInputGroupComponent {
 ```angular-ts title="input-group.variants.ts" expandable="true" expandableTitle="Expand" copyButton showLineNumbers
 import { cva, type VariantProps } from 'class-variance-authority';
 
+import { mergeClasses } from '../../shared/utils/utils';
+
 export const inputGroupVariants = cva(
-  'flex items-stretch w-full [&_input[z-input]]:!border-0 [&_input[z-input]]:!bg-transparent [&_input[z-input]]:!outline-none [&_input[z-input]]:!ring-0 [&_input[z-input]]:!ring-offset-0 [&_input[z-input]]:!px-0 [&_input[z-input]]:!py-0 [&_input[z-input]]:!h-full [&_input[z-input]]:flex-1 [&_textarea[z-input]]:!border-0 [&_textarea[z-input]]:!bg-transparent [&_textarea[z-input]]:!outline-none [&_textarea[z-input]]:!ring-0 [&_textarea[z-input]]:!ring-offset-0 [&_textarea[z-input]]:!px-0 [&_textarea[z-input]]:!py-0',
+  mergeClasses(
+    'rounded-md flex px-3 items-stretch w-full',
+    '[&_input[z-input]]:border-0! [&_input[z-input]]:bg-transparent! [&_input[z-input]]:outline-none!',
+    '[&_input[z-input]]:ring-0! [&_input[z-input]]:ring-offset-0! [&_input[z-input]]:px-0!',
+    '[&_input[z-input]]:py-0! [&_input[z-input]]:h-full! [&_input[z-input]]:flex-1',
+    '[&_textarea[z-input]]:border-0! [&_textarea[z-input]]:bg-transparent! [&_textarea[z-input]]:outline-none!',
+    '[&_textarea[z-input]]:ring-0! [&_textarea[z-input]]:ring-offset-0! [&_textarea[z-input]]:px-0! [&_textarea[z-input]]:py-0!',
+    'min-w-0 has-[textarea]:flex-col has-[textarea]:p-3 has-[textarea]:h-auto border border-input',
+    // focus state
+    'has-[[data-slot=input-group-control]:focus-visible]:border has-[[data-slot=input-group-control]:focus-visible]:border-ring has-[[data-slot=input-group-control]:focus-visible]:ring-ring/50 has-[[data-slot=input-group-control]:focus-visible]:ring-[3px]',
+  ),
   {
     variants: {
       zSize: {
-        sm: 'h-9',
-        default: 'h-10',
-        lg: 'h-11',
+        sm: 'h-8',
+        default: 'h-9',
+        lg: 'h-10',
       },
       zDisabled: {
         true: 'opacity-50 cursor-not-allowed',
@@ -168,13 +179,17 @@ export const inputGroupVariants = cva(
 );
 
 export const inputGroupAddonVariants = cva(
-  'addon inline-flex items-center justify-center whitespace-nowrap text-sm font-medium border border-input bg-muted text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
+  'items-center whitespace-nowrap font-medium text-muted-foreground transition-colors disabled:pointer-events-none disabled:opacity-50',
   {
     variants: {
+      zType: {
+        default: 'justify-center',
+        textarea: 'justify-start w-full',
+      },
       zSize: {
-        sm: 'h-9 px-3 text-xs',
-        default: 'h-10 px-3 text-sm',
-        lg: 'h-11 px-4 text-base',
+        sm: 'text-xs',
+        default: 'text-sm',
+        lg: 'text-base',
       },
       zPosition: {
         before: 'rounded-l-md border-r-0',
@@ -184,54 +199,59 @@ export const inputGroupAddonVariants = cva(
         true: 'cursor-not-allowed opacity-50 pointer-events-none',
         false: '',
       },
-      zBorderless: {
-        true: 'border-0 shadow-none',
-        false: '',
+      zAlign: {
+        block: 'flex',
+        inline: 'inline-flex',
       },
     },
     defaultVariants: {
-      zSize: 'default',
+      zAlign: 'inline',
       zPosition: 'before',
       zDisabled: false,
-      zBorderless: false,
+      zSize: 'default',
     },
+    compoundVariants: [
+      {
+        zType: 'default',
+        zSize: 'default',
+        class: 'h-8.5',
+      },
+      {
+        zType: 'default',
+        zSize: 'sm',
+        class: 'h-7.5',
+      },
+      {
+        zType: 'default',
+        zSize: 'lg',
+        class: 'h-9.5',
+      },
+      {
+        zType: 'textarea',
+        zPosition: 'before',
+        class: 'mb-2',
+      },
+      {
+        zType: 'textarea',
+        zPosition: 'after',
+        class: 'mt-2',
+      },
+    ],
   },
 );
 
-export const inputGroupAffixVariants = cva('absolute inset-y-0 flex items-center text-muted-foreground pointer-events-none z-10', {
-  variants: {
-    zSize: {
-      sm: 'text-xs',
-      default: 'text-sm',
-      lg: 'text-base',
-    },
-    zPosition: {
-      prefix: 'left-0 pl-3',
-      suffix: 'right-0 pr-3',
-    },
-  },
-  defaultVariants: {
-    zSize: 'default',
-    zPosition: 'prefix',
-  },
-});
-
 export const inputGroupInputVariants = cva(
-  'input-wrapper flex h-full w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-within:outline-none focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 transition-colors',
+  mergeClasses(
+    'font-normal flex has-[textarea]:h-auto w-full items-center rounded-md bg-background ring-offset-background',
+    'file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground',
+    'focus-within:outline-none disabled:cursor-not-allowed disabled:opacity-50 transition-colors',
+  ),
   {
     variants: {
       zSize: {
-        sm: 'h-9 px-3 py-1 text-sm',
-        default: 'h-10 px-3 py-2 text-sm',
-        lg: 'h-11 px-4 py-2 text-base',
-      },
-      zHasPrefix: {
-        true: '',
-        false: '',
-      },
-      zHasSuffix: {
-        true: '',
-        false: '',
+        sm: 'h-7.5 px-0.5 py-0 text-xs',
+        default: 'h-8.5 px-0.5 py-0 text-sm',
+        lg: 'h-9.5 px-0.5 py-0 text-base',
       },
       zHasAddonBefore: {
         true: 'border-l-0 rounded-l-none',
@@ -245,56 +265,20 @@ export const inputGroupInputVariants = cva(
         true: 'cursor-not-allowed opacity-50',
         false: '',
       },
-      zBorderless: {
-        true: 'border-0 bg-transparent shadow-none',
-        false: '',
-      },
     },
-    compoundVariants: [
-      {
-        zHasPrefix: true,
-        zSize: 'sm',
-        class: 'pl-7',
-      },
-      {
-        zHasPrefix: true,
-        zSize: 'default',
-        class: 'pl-8',
-      },
-      {
-        zHasPrefix: true,
-        zSize: 'lg',
-        class: 'pl-9',
-      },
-      {
-        zHasSuffix: true,
-        zSize: 'sm',
-        class: 'pr-12',
-      },
-      {
-        zHasSuffix: true,
-        zSize: 'default',
-        class: 'pr-14',
-      },
-      {
-        zHasSuffix: true,
-        zSize: 'lg',
-        class: 'pr-16',
-      },
-    ],
     defaultVariants: {
       zSize: 'default',
-      zHasPrefix: false,
-      zHasSuffix: false,
       zHasAddonBefore: false,
       zHasAddonAfter: false,
       zDisabled: false,
-      zBorderless: false,
     },
   },
 );
 
-export type ZardInputGroupVariants = VariantProps<typeof inputGroupVariants>;
+export type ZardInputGroupAddonAlignVariants = NonNullable<VariantProps<typeof inputGroupAddonVariants>['zAlign']>;
+export type ZardInputGroupAddonPositionVariants = NonNullable<
+  VariantProps<typeof inputGroupAddonVariants>['zPosition']
+>;
 
 ```
 

--- a/apps/web/public/installation/manual/input.md
+++ b/apps/web/public/installation/manual/input.md
@@ -1,34 +1,78 @@
 
 
 ```angular-ts title="input.directive.ts" expandable="true" expandableTitle="Expand" copyButton showLineNumbers
+import { computed, Directive, effect, ElementRef, inject, input, linkedSignal, model } from '@angular/core';
+
 import type { ClassValue } from 'clsx';
 
-import { computed, Directive, ElementRef, inject, input } from '@angular/core';
-
+import {
+  inputVariants,
+  type ZardInputSizeVariants,
+  type ZardInputStatusVariants,
+  type ZardInputTypeVariants,
+} from './input.variants';
 import { mergeClasses, transform } from '../../shared/utils/utils';
-import { inputVariants, type ZardInputVariants } from './input.variants';
 
 @Directive({
   selector: 'input[z-input], textarea[z-input]',
   exportAs: 'zInput',
-  standalone: true,
   host: {
     '[class]': 'classes()',
+    '(input)': 'updateValue($event.target)',
   },
 })
 export class ZardInputDirective {
-  readonly elementRef = inject(ElementRef);
-  private readonly isTextarea = this.elementRef.nativeElement.tagName.toLowerCase() === 'textarea';
-
-  readonly zBorderless = input(false, { transform });
-  readonly zSize = input<ZardInputVariants['zSize']>('default');
-  readonly zStatus = input<ZardInputVariants['zStatus']>();
+  private readonly elementRef = inject(ElementRef);
 
   readonly class = input<ClassValue>('');
+  readonly zBorderless = input(false, { transform });
+  readonly zSize = input<ZardInputSizeVariants>('default');
+  readonly zStatus = input<ZardInputStatusVariants>();
+  readonly value = model<string>('');
+
+  readonly size = linkedSignal<ZardInputSizeVariants>(() => this.zSize());
 
   protected readonly classes = computed(() =>
-    mergeClasses(inputVariants({ zType: !this.isTextarea ? 'default' : 'textarea', zSize: this.zSize(), zStatus: this.zStatus(), zBorderless: this.zBorderless() }), this.class()),
+    mergeClasses(
+      inputVariants({
+        zType: this.getType(),
+        zSize: this.size(),
+        zStatus: this.zStatus(),
+        zBorderless: this.zBorderless(),
+      }),
+      this.class(),
+    ),
   );
+
+  constructor() {
+    effect(() => {
+      const value = this.value();
+
+      if (value !== undefined && value !== null) {
+        this.elementRef.nativeElement.value = value;
+      }
+    });
+  }
+
+  disable(b: boolean): void {
+    this.elementRef.nativeElement.disabled = b;
+  }
+
+  setDataSlot(name: string): void {
+    if (this.elementRef?.nativeElement?.dataset) {
+      this.elementRef.nativeElement.dataset.slot = name;
+    }
+  }
+
+  protected updateValue(target: EventTarget | null): void {
+    const el = target as HTMLInputElement | HTMLTextAreaElement | null;
+    this.value.set(el?.value ?? '');
+  }
+
+  getType(): ZardInputTypeVariants {
+    const isTextarea = this.elementRef.nativeElement.tagName.toLowerCase() === 'textarea';
+    return isTextarea ? 'textarea' : 'default';
+  }
 }
 
 ```
@@ -44,14 +88,14 @@ export const inputVariants = cva('w-full', {
   variants: {
     zType: {
       default:
-        'flex rounded-md border px-4 font-normal border-input bg-transparent text-base md:text-sm file:border-0 file:text-foreground file:bg-transparent file:font-medium placeholder:text-muted-foreground outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50',
+        'flex rounded-md border px-4 font-normal border-input bg-transparent file:border-0 file:text-foreground file:bg-transparent file:font-medium placeholder:text-muted-foreground outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50',
       textarea:
-        'flex min-h-[80px] rounded-md border border-input bg-background px-3 py-2 text-base placeholder:text-muted-foreground outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+        'flex pb-2 min-h-20 h-auto rounded-md border border-input bg-background px-3 py-2 text-base placeholder:text-muted-foreground outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50',
     },
     zSize: {
-      default: 'h-10 py-2 file:max-md:py-0',
-      sm: 'h-9 file:md:py-2 file:max-md:py-1.5',
-      lg: 'h-11 py-1 file:md:py-3 file:max-md:py-2.5',
+      default: 'text-sm',
+      sm: 'text-xs',
+      lg: 'text-base',
     },
     zStatus: {
       error: 'border-destructive focus-visible:ring-destructive',
@@ -66,9 +110,16 @@ export const inputVariants = cva('w-full', {
     zType: 'default',
     zSize: 'default',
   },
+  compoundVariants: [
+    { zType: 'default', zSize: 'default', class: 'h-9 py-2 file:max-md:py-0' },
+    { zType: 'default', zSize: 'sm', class: 'h-8 file:md:py-2 file:max-md:py-1.5' },
+    { zType: 'default', zSize: 'lg', class: 'h-10 py-1 file:md:py-3 file:max-md:py-2.5' },
+  ],
 });
 
-export type ZardInputVariants = VariantProps<typeof inputVariants>;
+export type ZardInputTypeVariants = NonNullable<VariantProps<typeof inputVariants>['zType']>;
+export type ZardInputSizeVariants = NonNullable<VariantProps<typeof inputVariants>['zSize']>;
+export type ZardInputStatusVariants = NonNullable<VariantProps<typeof inputVariants>['zStatus']>;
 
 ```
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -177,6 +177,17 @@
   .no-bullets li::marker {
     content: '';
   }
+
+  input[type='number']::-webkit-inner-spin-button,
+  input[type='number']::-webkit-outer-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
+
+  input[type='number'] {
+    -moz-appearance: textfield;
+    appearance: textfield; /* Added for general compatibility */
+  }
 }
 
 @utility border-grid {

--- a/libs/zard/src/lib/components/button/doc/api.md
+++ b/libs/zard/src/lib/components/button/doc/api.md
@@ -5,7 +5,7 @@
 | Property   | Description          | Type                                                              | Default   |
 | ---------- | -------------------- | ----------------------------------------------------------------- | --------- |
 | `zType`    | button type          | `default \| destructive \| outline \| secondary \| ghost \| link` | `default` |
-| `zSize`    | button size          | `default \| sm \| lg \|icon`                                      | `default` |
+| `zSize`    | button size          | `default \| sm \| lg`                                             | `default` |
 | `zShape`   | button shape         | `default \| circle \| square`                                     | `default` |
 | `zFull`    | button width 100%    | `boolean`                                                         | `false`   |
 | `zLoading` | button loading state | `boolean`                                                         | `false`   |

--- a/libs/zard/src/lib/components/input-group/demo/borderless.ts
+++ b/libs/zard/src/lib/components/input-group/demo/borderless.ts
@@ -1,23 +1,23 @@
-import { Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 
 import { ZardInputDirective } from '../../input/input.directive';
 import { ZardInputGroupComponent } from '../input-group.component';
 
 @Component({
   selector: 'z-demo-input-group-borderless',
-  standalone: true,
   imports: [ZardInputGroupComponent, ZardInputDirective],
+  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <div class="flex flex-col space-y-4">
-      <z-input-group zPrefix="$" zSuffix="USD" zBorderless>
+      <z-input-group zAddonBefore="$" zAddonAfter="USD" class="border-0">
         <input z-input placeholder="0.00" type="number" />
       </z-input-group>
 
-      <z-input-group zAddOnBefore="https://" zAddOnAfter=".com" zBorderless>
+      <z-input-group zAddonBefore="https://" zAddonAfter=".com" class="border-0">
         <input z-input placeholder="example" />
       </z-input-group>
 
-      <z-input-group zAddOnBefore="@" zBorderless>
+      <z-input-group zAddonBefore="@" class="border-0">
         <input z-input placeholder="username" />
       </z-input-group>
     </div>

--- a/libs/zard/src/lib/components/input-group/demo/default.ts
+++ b/libs/zard/src/lib/components/input-group/demo/default.ts
@@ -1,26 +1,75 @@
 import { Component } from '@angular/core';
 
+import { ZardButtonComponent } from '../../button/button.component';
+import { ZardDividerComponent } from '../../divider/divider.component';
+import { ZardDropdownModule } from '../../dropdown/dropdown.module';
+import { ZardIconComponent } from '../../icon/icon.component';
 import { ZardInputDirective } from '../../input/input.directive';
+import { ZardTooltipDirective } from '../../tooltip/tooltip';
 import { ZardInputGroupComponent } from '../input-group.component';
 
 @Component({
   selector: 'z-demo-input-group-default',
-  standalone: true,
-  imports: [ZardInputGroupComponent, ZardInputDirective],
+  imports: [
+    ZardButtonComponent,
+    ZardDropdownModule,
+    ZardIconComponent,
+    ZardInputDirective,
+    ZardInputGroupComponent,
+    ZardDividerComponent,
+    ZardTooltipDirective,
+  ],
   template: `
-    <div class="flex flex-col space-y-4">
-      <z-input-group zAddOnBefore="https://" zAddOnAfter=".com" class="mb-4">
-        <input z-input placeholder="example" />
+    <div class="flex w-[380px] flex-col space-y-4">
+      <z-input-group [zAddonBefore]="search" zAddonAfter="12 results" class="mb-4">
+        <input z-input placeholder="Search..." />
       </z-input-group>
 
-      <z-input-group zPrefix="$" zSuffix="USD" class="mb-4">
-        <input z-input placeholder="0.00" type="number" />
+      <z-input-group zAddonBefore="https://" [zAddonAfter]="info" class="mb-4">
+        <input z-input placeholder="example.com" />
       </z-input-group>
 
-      <z-input-group zAddOnBefore="@">
-        <input z-input placeholder="username" />
+      <z-input-group class="mb-4" [zAddonAfter]="areaAfter">
+        <textarea class="h-30 resize-none" z-input placeholder="Ask, Search or Chat..."></textarea>
+      </z-input-group>
+
+      <z-input-group [zAddonAfter]="check">
+        <input z-input placeholder="@zardui" />
       </z-input-group>
     </div>
+
+    <ng-template #search><z-icon zType="search" /></ng-template>
+
+    <ng-template #check>
+      <div class="bg-primary rounded-full p-0.5">
+        <z-icon zType="check" class="stroke-primary-foreground" zSize="sm" />
+      </div>
+    </ng-template>
+
+    <ng-template #info><z-icon zType="info" zTooltip="Element with tooltip" /></ng-template>
+
+    <ng-template #areaAfter>
+      <div class="flex w-full items-center justify-between">
+        <div class="flex items-center gap-1">
+          <button type="button" z-button zType="outline" zShape="circle" class="data-icon-only:size-6!">
+            <z-icon zType="plus" />
+          </button>
+          <button type="button" z-button zType="ghost" class="h-6" z-dropdown [zDropdownMenu]="menu">Auto</button>
+          <z-dropdown-menu-content #menu="zDropdownMenuContent" class="w-10">
+            <z-dropdown-menu-item> Auto </z-dropdown-menu-item>
+            <z-dropdown-menu-item> Agent </z-dropdown-menu-item>
+            <z-dropdown-menu-item> Manual </z-dropdown-menu-item>
+          </z-dropdown-menu-content>
+        </div>
+        <div class="flex h-auto items-center gap-0">
+          <span>52% used</span>
+          <z-divider zOrientation="vertical" class="h-4" />
+          <button type="button" z-button zType="outline" zShape="circle" class="data-icon-only:size-6!">
+            <z-icon zType="arrow-up" />
+          </button>
+        </div>
+      </div>
+    </ng-template>
   `,
 })
 export class ZardDemoInputGroupDefaultComponent {}

--- a/libs/zard/src/lib/components/input-group/demo/input-group.ts
+++ b/libs/zard/src/lib/components/input-group/demo/input-group.ts
@@ -1,6 +1,8 @@
 import { ZardDemoInputGroupBorderlessComponent } from './borderless';
 import { ZardDemoInputGroupDefaultComponent } from './default';
+import { ZardDemoInputGroupLoadingComponent } from './loading';
 import { ZardDemoInputGroupSizeComponent } from './size';
+import { ZardDemoInputGroupTextComponent } from './text';
 
 export const INPUT_GROUP = {
   componentName: 'input-group',
@@ -13,6 +15,12 @@ export const INPUT_GROUP = {
       column: true,
     },
     {
+      name: 'text',
+      component: ZardDemoInputGroupTextComponent,
+      column: true,
+    },
+
+    {
       name: 'size',
       component: ZardDemoInputGroupSizeComponent,
       column: true,
@@ -20,6 +28,11 @@ export const INPUT_GROUP = {
     {
       name: 'borderless',
       component: ZardDemoInputGroupBorderlessComponent,
+      column: true,
+    },
+    {
+      name: 'loading',
+      component: ZardDemoInputGroupLoadingComponent,
       column: true,
     },
   ],

--- a/libs/zard/src/lib/components/input-group/demo/loading.ts
+++ b/libs/zard/src/lib/components/input-group/demo/loading.ts
@@ -1,0 +1,21 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+
+import { ZardIconComponent } from '../../icon/icon.component';
+import { ZardInputDirective } from '../../input/input.directive';
+import { ZardInputGroupComponent } from '../input-group.component';
+
+@Component({
+  selector: 'z-demo-input-group-loading',
+  imports: [ZardInputGroupComponent, ZardInputDirective, ZardIconComponent],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div class="flex flex-col space-y-4">
+      <z-input-group [zAddonBefore]="search" zLoading>
+        <input z-input type="text" placeholder="Search..." />
+      </z-input-group>
+    </div>
+
+    <ng-template #search><z-icon zType="search" /></ng-template>
+  `,
+})
+export class ZardDemoInputGroupLoadingComponent {}

--- a/libs/zard/src/lib/components/input-group/demo/size.ts
+++ b/libs/zard/src/lib/components/input-group/demo/size.ts
@@ -1,25 +1,24 @@
-import { Component } from '@angular/core';
-import { FormsModule } from '@angular/forms';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 
 import { ZardInputDirective } from '../../input/input.directive';
 import { ZardInputGroupComponent } from '../input-group.component';
 
 @Component({
   selector: 'z-demo-input-group-size',
-  standalone: true,
-  imports: [ZardInputGroupComponent, ZardInputDirective, FormsModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [ZardInputGroupComponent, ZardInputDirective],
   template: `
     <div class="flex flex-col space-y-4">
-      <z-input-group zSize="sm" zAddOnBefore="@" zAddOnAfter=".com" class="mb-4">
-        <input z-input placeholder="Small" [(ngModel)]="smallValue" />
+      <z-input-group zSize="sm" zAddonBefore="https://" zAddonAfter=".com" class="mb-4">
+        <input z-input placeholder="Small" [(value)]="smallValue" />
       </z-input-group>
 
-      <z-input-group zSize="default" zAddOnBefore="@" zAddOnAfter=".com" class="mb-4">
-        <input z-input placeholder="Default" [(ngModel)]="defaultValue" />
+      <z-input-group zSize="default" zAddonBefore="https://" zAddonAfter=".com" class="mb-4">
+        <input z-input placeholder="Default" [(value)]="defaultValue" />
       </z-input-group>
 
-      <z-input-group zSize="lg" zAddOnBefore="@" zAddOnAfter=".com">
-        <input z-input placeholder="Large" [(ngModel)]="largeValue" />
+      <z-input-group zSize="lg" zAddonBefore="https://" zAddonAfter=".com">
+        <input z-input placeholder="Large" [(value)]="largeValue" />
       </z-input-group>
     </div>
   `,

--- a/libs/zard/src/lib/components/input-group/demo/text.ts
+++ b/libs/zard/src/lib/components/input-group/demo/text.ts
@@ -1,0 +1,36 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+
+import { ZardButtonComponent } from '../../button/button.component';
+import { ZardInputDirective } from '../../input/input.directive';
+import { ZardInputGroupComponent } from '../input-group.component';
+
+@Component({
+  selector: 'z-demo-input-group-text',
+  imports: [ZardInputGroupComponent, ZardInputDirective, ZardButtonComponent],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <z-input-group zAddonBefore="$" zAddonAfter="USD" class="mb-4">
+      <input z-input placeholder="0.00" type="number" />
+    </z-input-group>
+
+    <z-input-group zAddonBefore="https://" zAddonAfter=".com" class="mb-4">
+      <input z-input placeholder="example.com" />
+    </z-input-group>
+
+    <z-input-group zAddonAfter="@company.com" class="mb-4">
+      <input z-input placeholder="Enter your username" />
+    </z-input-group>
+
+    <z-input-group [zAddonAfter]="actions" class="mb-4">
+      <textarea z-input class="resize-none" placeholder="Enter your message"></textarea>
+    </z-input-group>
+
+    <ng-template #actions>
+      <div class="flex w-full items-center justify-between">
+        <span class="text-muted-foreground text-xs">120 characters left</span>
+        <button type="submit" z-button zSize="sm">Submit</button>
+      </div>
+    </ng-template>
+  `,
+})
+export class ZardDemoInputGroupTextComponent {}

--- a/libs/zard/src/lib/components/input-group/doc/api.md
+++ b/libs/zard/src/lib/components/input-group/doc/api.md
@@ -4,20 +4,12 @@
 
 ### z-input-group
 
-| Input                   | Type                                | Default     | Description                                    |
-| ----------------------- | ----------------------------------- | ----------- | ---------------------------------------------- |
-| `zSize`                 | `'sm' \| 'default' \| 'lg'`         | `'default'` | Size of the input group and all its elements   |
-| `zDisabled`             | `boolean`                           | `false`     | Disable the entire input group                 |
-| `zBorderless`           | `boolean`                           | `false`     | Remove borders and background for a clean look |
-| `zAddOnBefore`          | `string \| TemplateRef<void>`       | `undefined` | Content to display before the input            |
-| `zAddOnAfter`           | `string \| TemplateRef<void>`       | `undefined` | Content to display after the input             |
-| `zPrefix`               | `string \| TemplateRef<void>`       | `undefined` | Prefix content inside the input (left)         |
-| `zSuffix`               | `string \| TemplateRef<void>`       | `undefined` | Suffix content inside the input (right)        |
-| `zAriaLabel`            | `string`                            | `undefined` | Accessibility label for the input group        |
-| `zAriaLabelledBy`       | `string`                            | `undefined` | ID of element that labels the input group      |
-| `zAriaDescribedBy`      | `string`                            | `undefined` | ID of element that describes the input group   |
-| `zAddOnBeforeAriaLabel` | `string`                            | `undefined` | Accessibility label for the before addon       |
-| `zAddOnAfterAriaLabel`  | `string`                            | `undefined` | Accessibility label for the after addon        |
-| `zPrefixAriaLabel`      | `string`                            | `undefined` | Accessibility label for the prefix             |
-| `zSuffixAriaLabel`      | `string`                            | `undefined` | Accessibility label for the suffix             |
-| `class`                 | `ClassValue`                        | `''`        | Additional CSS classes                         |
+| Input          | Type                          | Default     | Description                                  |
+| -------------- | ----------------------------- | ----------- | -------------------------------------------- |
+| `class`        | `ClassValue`                  | `''`        | Custom CSS classes                           |
+| `zAddonAlign`  | `'inline' \| 'block'`         | `inline`    | Addon alignment                              |
+| `zAddonAfter`  | `string \| TemplateRef<void>` | `''`        | Addon after input                            |
+| `zAddonBefore` | `string \| TemplateRef<void>` | `''`        | Addon before input                           |
+| `zDisabled`    | `boolean`                     | `false`     | Disable the entire input group               |
+| `zLoading`     | `boolean`                     | `false`     | Loading state with spinner                   |
+| `zSize`        | `'sm' \| 'default' \| 'lg'`   | `'default'` | Size of the input group and all its elements |

--- a/libs/zard/src/lib/components/input-group/input-group.component.spec.ts
+++ b/libs/zard/src/lib/components/input-group/input-group.component.spec.ts
@@ -3,42 +3,25 @@ import { type ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ZardInputGroupComponent } from './input-group.component';
 import { ZardInputDirective } from '../input/input.directive';
-import { inputVariants } from '../input/input.variants';
+import { inputVariants, type ZardInputSizeVariants } from '../input/input.variants';
 
 @Component({
   standalone: true,
   imports: [ZardInputGroupComponent, ZardInputDirective],
   template: `
     <ng-template #customTemplate>Custom Template</ng-template>
-    <z-input-group
-      [zSize]="size"
-      [zDisabled]="disabled"
-      [zBorderless]="borderless"
-      [zAddOnBefore]="addOnBefore"
-      [zAddOnAfter]="addOnAfter"
-      [zPrefix]="prefix"
-      [zSuffix]="suffix"
-      [zAriaLabel]="ariaLabel"
-      [zAriaLabelledBy]="ariaLabelledBy"
-      [zAriaDescribedBy]="ariaDescribedBy"
-    >
+    <z-input-group [zSize]="size" [zDisabled]="disabled" [zAddonBefore]="addonBefore" [zAddonAfter]="addonAfter">
       <input z-input type="text" placeholder="Test input" />
     </z-input-group>
   `,
 })
 class TestHostComponent {
-  @ViewChild('customTemplate', { static: true }) customTemplate!: TemplateRef<any>;
+  @ViewChild('customTemplate', { static: true }) customTemplate!: TemplateRef<void>;
 
-  size: 'sm' | 'default' | 'lg' = 'default';
+  size: ZardInputSizeVariants = 'default';
   disabled = false;
-  borderless = false;
-  addOnBefore: string | TemplateRef<any> | undefined;
-  addOnAfter: string | TemplateRef<any> | undefined;
-  prefix: string | TemplateRef<any> | undefined;
-  suffix: string | TemplateRef<any> | undefined;
-  ariaLabel?: string;
-  ariaLabelledBy?: string;
-  ariaDescribedBy?: string;
+  addonBefore: string | TemplateRef<void> = '';
+  addonAfter: string | TemplateRef<void> = '';
 }
 
 describe('ZardInputGroupComponent', () => {
@@ -67,7 +50,6 @@ describe('ZardInputGroupComponent', () => {
     it('should have default values', () => {
       expect(component.zSize()).toBe('default');
       expect(component.zDisabled()).toBe(false);
-      expect(component.zBorderless()).toBe(false);
     });
   });
 
@@ -79,24 +61,15 @@ describe('ZardInputGroupComponent', () => {
     });
 
     it('should handle size variants', () => {
-      const sizes: Array<'sm' | 'default' | 'lg'> = ['sm', 'default', 'lg'];
+      const sizes: Array<ZardInputSizeVariants> = ['sm', 'default', 'lg'];
 
       sizes.forEach(size => {
         hostComponent.size = size;
         hostFixture.detectChanges();
 
         const wrapper = hostFixture.debugElement.nativeElement.querySelector('[role="group"]');
-        expect(wrapper.className).toContain(size === 'sm' ? 'h-9' : size === 'lg' ? 'h-11' : 'h-10');
+        expect(wrapper.className).toContain(size === 'sm' ? 'h-8' : size === 'lg' ? 'h-10' : 'h-9');
       });
-    });
-
-    it('should apply borderless styles', () => {
-      hostComponent.borderless = true;
-      hostFixture.detectChanges();
-
-      const wrapper = hostFixture.debugElement.nativeElement.querySelector('[role="group"]');
-      // Check for borderless-related styles based on your variants
-      expect(wrapper).toBeTruthy();
     });
 
     it('should apply disabled state', () => {
@@ -116,7 +89,7 @@ describe('ZardInputGroupComponent', () => {
     });
 
     it('should render addon before with string', () => {
-      hostComponent.addOnBefore = 'https://';
+      hostComponent.addonBefore = 'https://';
       hostFixture.detectChanges();
 
       const addon = hostFixture.debugElement.nativeElement.querySelector('[id*="addon-before"]');
@@ -127,7 +100,7 @@ describe('ZardInputGroupComponent', () => {
     });
 
     it('should render addon after with string', () => {
-      hostComponent.addOnAfter = '.com';
+      hostComponent.addonAfter = '.com';
       hostFixture.detectChanges();
 
       const addon = hostFixture.debugElement.nativeElement.querySelector('[id*="addon-after"]');
@@ -138,7 +111,7 @@ describe('ZardInputGroupComponent', () => {
     });
 
     it('should render addon before with template', () => {
-      hostComponent.addOnBefore = hostComponent.customTemplate;
+      hostComponent.addonBefore = hostComponent.customTemplate;
       hostFixture.detectChanges();
 
       const addon = hostFixture.debugElement.nativeElement.querySelector('[id*="addon-before"]');
@@ -147,8 +120,8 @@ describe('ZardInputGroupComponent', () => {
     });
 
     it('should handle both addons together', () => {
-      hostComponent.addOnBefore = 'Before';
-      hostComponent.addOnAfter = 'After';
+      hostComponent.addonBefore = 'Before';
+      hostComponent.addonAfter = 'After';
       hostFixture.detectChanges();
 
       const beforeAddon = hostFixture.debugElement.nativeElement.querySelector('[id*="addon-before"]');
@@ -168,133 +141,6 @@ describe('ZardInputGroupComponent', () => {
     });
   });
 
-  describe('Affix Elements', () => {
-    beforeEach(() => {
-      hostFixture = TestBed.createComponent(TestHostComponent);
-      hostComponent = hostFixture.componentInstance;
-    });
-
-    it('should render prefix with string', () => {
-      hostComponent.prefix = '$';
-      hostFixture.detectChanges();
-
-      const prefix = hostFixture.debugElement.nativeElement.querySelector('[id*="prefix"]');
-      expect(prefix).toBeTruthy();
-      expect(prefix.textContent.trim()).toBe('$');
-      expect(prefix.className).toContain('left-0');
-      expect(prefix.className).toContain('pl-3');
-      expect(prefix.getAttribute('aria-hidden')).toBe('true');
-    });
-
-    it('should render suffix with string', () => {
-      hostComponent.suffix = 'USD';
-      hostFixture.detectChanges();
-
-      const suffix = hostFixture.debugElement.nativeElement.querySelector('[id*="suffix"]');
-      expect(suffix).toBeTruthy();
-      expect(suffix.textContent.trim()).toBe('USD');
-      expect(suffix.className).toContain('right-0');
-      expect(suffix.className).toContain('pr-3');
-      expect(suffix.getAttribute('aria-hidden')).toBe('true');
-    });
-
-    it('should render prefix with template', () => {
-      hostComponent.prefix = hostComponent.customTemplate;
-      hostFixture.detectChanges();
-
-      const prefix = hostFixture.debugElement.nativeElement.querySelector('[id*="prefix"]');
-      expect(prefix).toBeTruthy();
-      expect(prefix.textContent.trim()).toBe('Custom Template');
-    });
-
-    it('should adjust input padding for prefix', () => {
-      hostComponent.prefix = '$';
-      hostComponent.size = 'default';
-      hostFixture.detectChanges();
-
-      const inputWrapper = hostFixture.debugElement.nativeElement.querySelector('.relative');
-      expect(inputWrapper.className).toContain('pl-8');
-    });
-
-    it('should adjust input padding for suffix', () => {
-      hostComponent.suffix = 'USD';
-      hostComponent.size = 'default';
-      hostFixture.detectChanges();
-
-      const inputWrapper = hostFixture.debugElement.nativeElement.querySelector('.relative');
-      expect(inputWrapper.className).toContain('pr-14');
-    });
-
-    it('should handle both prefix and suffix together', () => {
-      hostComponent.prefix = '$';
-      hostComponent.suffix = 'USD';
-      hostComponent.size = 'default';
-      hostFixture.detectChanges();
-
-      const inputWrapper = hostFixture.debugElement.nativeElement.querySelector('.relative');
-      expect(inputWrapper.className).toContain('pl-8');
-      expect(inputWrapper.className).toContain('pr-14');
-    });
-  });
-
-  describe('Accessibility', () => {
-    beforeEach(() => {
-      hostFixture = TestBed.createComponent(TestHostComponent);
-      hostComponent = hostFixture.componentInstance;
-    });
-
-    it('should set proper role attribute', () => {
-      hostFixture.detectChanges();
-
-      const wrapper = hostFixture.debugElement.nativeElement.querySelector('[role="group"]');
-      expect(wrapper).toBeTruthy();
-    });
-
-    it('should handle aria-label', () => {
-      hostComponent.ariaLabel = 'Test input group';
-      hostFixture.detectChanges();
-
-      const wrapper = hostFixture.debugElement.nativeElement.querySelector('[role="group"]');
-      expect(wrapper.getAttribute('aria-label')).toBe('Test input group');
-    });
-
-    it('should handle aria-labelledby', () => {
-      hostComponent.ariaLabelledBy = 'label-id';
-      hostFixture.detectChanges();
-
-      const wrapper = hostFixture.debugElement.nativeElement.querySelector('[role="group"]');
-      expect(wrapper.getAttribute('aria-labelledby')).toBe('label-id');
-    });
-
-    it('should handle aria-describedby', () => {
-      hostComponent.ariaDescribedBy = 'desc-id';
-      hostFixture.detectChanges();
-
-      const wrapper = hostFixture.debugElement.nativeElement.querySelector('[role="group"]');
-      expect(wrapper.getAttribute('aria-describedby')).toBe('desc-id');
-    });
-
-    it('should set aria-disabled when disabled', () => {
-      hostComponent.disabled = true;
-      hostFixture.detectChanges();
-
-      const wrapper = hostFixture.debugElement.nativeElement.querySelector('[role="group"]');
-      expect(wrapper.getAttribute('aria-disabled')).toBe('true');
-    });
-
-    it('should set aria-hidden on affix elements', () => {
-      hostComponent.prefix = '$';
-      hostComponent.suffix = 'USD';
-      hostFixture.detectChanges();
-
-      const prefix = hostFixture.debugElement.nativeElement.querySelector('[id*="prefix"]');
-      const suffix = hostFixture.debugElement.nativeElement.querySelector('[id*="suffix"]');
-
-      expect(prefix.getAttribute('aria-hidden')).toBe('true');
-      expect(suffix.getAttribute('aria-hidden')).toBe('true');
-    });
-  });
-
   describe('Size Variations', () => {
     beforeEach(() => {
       hostFixture = TestBed.createComponent(TestHostComponent);
@@ -306,7 +152,7 @@ describe('ZardInputGroupComponent', () => {
       hostFixture.detectChanges();
 
       const wrapper = hostFixture.debugElement.nativeElement.querySelector('[role="group"]');
-      expect(wrapper.className).toContain('h-9');
+      expect(wrapper.className).toContain('h-8');
     });
 
     it('should apply correct height for large size', () => {
@@ -314,27 +160,17 @@ describe('ZardInputGroupComponent', () => {
       hostFixture.detectChanges();
 
       const wrapper = hostFixture.debugElement.nativeElement.querySelector('[role="group"]');
-      expect(wrapper.className).toContain('h-11');
+      expect(wrapper.className).toContain('h-10');
     });
 
     it('should adjust addon size based on group size', () => {
-      hostComponent.addOnBefore = 'Test';
+      hostComponent.addonBefore = 'Test';
       hostComponent.size = 'sm';
       hostFixture.detectChanges();
 
       const addon = hostFixture.debugElement.nativeElement.querySelector('[id*="addon-before"]');
-      expect(addon.className).toContain('h-9');
-      expect(addon.className).toContain('px-3');
+      expect(addon.className).toContain('h-7.5');
       expect(addon.className).toContain('text-xs');
-    });
-
-    it('should adjust affix size based on group size', () => {
-      hostComponent.prefix = '$';
-      hostComponent.size = 'lg';
-      hostFixture.detectChanges();
-
-      const prefix = hostFixture.debugElement.nativeElement.querySelector('[id*="prefix"]');
-      expect(prefix.className).toContain('text-base');
     });
   });
 
@@ -346,37 +182,23 @@ describe('ZardInputGroupComponent', () => {
 
     it('should handle all props together', () => {
       hostComponent.size = 'lg';
-      hostComponent.borderless = true;
       hostComponent.disabled = true;
-      hostComponent.addOnBefore = 'https://';
-      hostComponent.addOnAfter = '.com';
-      hostComponent.prefix = 'www.';
-      hostComponent.suffix = '/path';
-      hostComponent.ariaLabel = 'Complex input group';
+      hostComponent.addonBefore = 'https://';
+      hostComponent.addonAfter = '.com';
       hostFixture.detectChanges();
 
       const wrapper = hostFixture.debugElement.nativeElement.querySelector('[role="group"]');
       const beforeAddon = hostFixture.debugElement.nativeElement.querySelector('[id*="addon-before"]');
       const afterAddon = hostFixture.debugElement.nativeElement.querySelector('[id*="addon-after"]');
-      const prefix = hostFixture.debugElement.nativeElement.querySelector('[id*="prefix"]');
-      const suffix = hostFixture.debugElement.nativeElement.querySelector('[id*="suffix"]');
 
       // Check wrapper
-      expect(wrapper.className).toContain('h-11'); // lg size
-      expect(wrapper.getAttribute('aria-label')).toBe('Complex input group');
-      expect(wrapper.getAttribute('aria-disabled')).toBe('true');
+      expect(wrapper.className).toContain('h-10'); // lg size
 
       // Check addons
       expect(beforeAddon).toBeTruthy();
       expect(afterAddon).toBeTruthy();
       expect(beforeAddon.textContent.trim()).toBe('https://');
       expect(afterAddon.textContent.trim()).toBe('.com');
-
-      // Check affixes
-      expect(prefix).toBeTruthy();
-      expect(suffix).toBeTruthy();
-      expect(prefix.textContent.trim()).toBe('www.');
-      expect(suffix.textContent.trim()).toBe('/path');
     });
 
     it('should handle input-only scenario', () => {
@@ -401,20 +223,14 @@ describe('ZardInputGroupComponent', () => {
     it('should generate unique IDs', () => {
       fixture.detectChanges();
 
-      const id1 = component['addonBeforeId']();
-      const id2 = component['addonAfterId']();
-      const id3 = component['prefixId']();
-      const id4 = component['suffixId']();
+      const id1 = component['addonBeforeId'];
+      const id2 = component['addonAfterId'];
 
       expect(id1).toMatch(/input-group-.*-addon-before/);
       expect(id2).toMatch(/input-group-.*-addon-after/);
-      expect(id3).toMatch(/input-group-.*-prefix/);
-      expect(id4).toMatch(/input-group-.*-suffix/);
 
       // IDs should be unique
       expect(id1).not.toBe(id2);
-      expect(id1).not.toBe(id3);
-      expect(id1).not.toBe(id4);
     });
 
     it('should compute wrapper classes correctly', () => {
@@ -422,14 +238,13 @@ describe('ZardInputGroupComponent', () => {
       fixture.componentRef.setInput('zDisabled', true);
       fixture.detectChanges();
 
-      const classes = component['wrapperClasses']();
-      expect(classes).toContain('h-11');
+      const classes = component['inputWrapperClasses']();
+      expect(classes).toContain('h-9.5');
     });
   });
 });
 
 describe('ZardInputDirective', () => {
-  let directive: ZardInputDirective;
   let fixture: ComponentFixture<TestHostComponent>;
 
   beforeEach(async () => {

--- a/libs/zard/src/lib/components/input-group/input-group.variants.ts
+++ b/libs/zard/src/lib/components/input-group/input-group.variants.ts
@@ -1,13 +1,25 @@
 import { cva, type VariantProps } from 'class-variance-authority';
 
+import { mergeClasses } from '../../shared/utils/utils';
+
 export const inputGroupVariants = cva(
-  'flex items-stretch w-full [&_input[z-input]]:!border-0 [&_input[z-input]]:!bg-transparent [&_input[z-input]]:!outline-none [&_input[z-input]]:!ring-0 [&_input[z-input]]:!ring-offset-0 [&_input[z-input]]:!px-0 [&_input[z-input]]:!py-0 [&_input[z-input]]:!h-full [&_input[z-input]]:flex-1 [&_textarea[z-input]]:!border-0 [&_textarea[z-input]]:!bg-transparent [&_textarea[z-input]]:!outline-none [&_textarea[z-input]]:!ring-0 [&_textarea[z-input]]:!ring-offset-0 [&_textarea[z-input]]:!px-0 [&_textarea[z-input]]:!py-0',
+  mergeClasses(
+    'rounded-md flex px-3 items-stretch w-full',
+    '[&_input[z-input]]:border-0! [&_input[z-input]]:bg-transparent! [&_input[z-input]]:outline-none!',
+    '[&_input[z-input]]:ring-0! [&_input[z-input]]:ring-offset-0! [&_input[z-input]]:px-0!',
+    '[&_input[z-input]]:py-0! [&_input[z-input]]:h-full! [&_input[z-input]]:flex-1',
+    '[&_textarea[z-input]]:border-0! [&_textarea[z-input]]:bg-transparent! [&_textarea[z-input]]:outline-none!',
+    '[&_textarea[z-input]]:ring-0! [&_textarea[z-input]]:ring-offset-0! [&_textarea[z-input]]:px-0! [&_textarea[z-input]]:py-0!',
+    'min-w-0 has-[textarea]:flex-col has-[textarea]:p-3 has-[textarea]:h-auto border border-input',
+    // focus state
+    'has-[[data-slot=input-group-control]:focus-visible]:border has-[[data-slot=input-group-control]:focus-visible]:border-ring has-[[data-slot=input-group-control]:focus-visible]:ring-ring/50 has-[[data-slot=input-group-control]:focus-visible]:ring-[3px]',
+  ),
   {
     variants: {
       zSize: {
-        sm: 'h-9',
-        default: 'h-10',
-        lg: 'h-11',
+        sm: 'h-8',
+        default: 'h-9',
+        lg: 'h-10',
       },
       zDisabled: {
         true: 'opacity-50 cursor-not-allowed',
@@ -22,13 +34,17 @@ export const inputGroupVariants = cva(
 );
 
 export const inputGroupAddonVariants = cva(
-  'addon inline-flex items-center justify-center whitespace-nowrap text-sm font-medium border border-input bg-muted text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
+  'items-center whitespace-nowrap font-medium text-muted-foreground transition-colors disabled:pointer-events-none disabled:opacity-50',
   {
     variants: {
+      zType: {
+        default: 'justify-center',
+        textarea: 'justify-start w-full',
+      },
       zSize: {
-        sm: 'h-9 px-3 text-xs',
-        default: 'h-10 px-3 text-sm',
-        lg: 'h-11 px-4 text-base',
+        sm: 'text-xs',
+        default: 'text-sm',
+        lg: 'text-base',
       },
       zPosition: {
         before: 'rounded-l-md border-r-0',
@@ -38,54 +54,59 @@ export const inputGroupAddonVariants = cva(
         true: 'cursor-not-allowed opacity-50 pointer-events-none',
         false: '',
       },
-      zBorderless: {
-        true: 'border-0 shadow-none',
-        false: '',
+      zAlign: {
+        block: 'flex',
+        inline: 'inline-flex',
       },
     },
     defaultVariants: {
-      zSize: 'default',
+      zAlign: 'inline',
       zPosition: 'before',
       zDisabled: false,
-      zBorderless: false,
+      zSize: 'default',
     },
+    compoundVariants: [
+      {
+        zType: 'default',
+        zSize: 'default',
+        class: 'h-8.5',
+      },
+      {
+        zType: 'default',
+        zSize: 'sm',
+        class: 'h-7.5',
+      },
+      {
+        zType: 'default',
+        zSize: 'lg',
+        class: 'h-9.5',
+      },
+      {
+        zType: 'textarea',
+        zPosition: 'before',
+        class: 'mb-2',
+      },
+      {
+        zType: 'textarea',
+        zPosition: 'after',
+        class: 'mt-2',
+      },
+    ],
   },
 );
 
-export const inputGroupAffixVariants = cva('absolute inset-y-0 flex items-center text-muted-foreground pointer-events-none z-10', {
-  variants: {
-    zSize: {
-      sm: 'text-xs',
-      default: 'text-sm',
-      lg: 'text-base',
-    },
-    zPosition: {
-      prefix: 'left-0 pl-3',
-      suffix: 'right-0 pr-3',
-    },
-  },
-  defaultVariants: {
-    zSize: 'default',
-    zPosition: 'prefix',
-  },
-});
-
 export const inputGroupInputVariants = cva(
-  'input-wrapper flex h-full w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-within:outline-none focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 transition-colors',
+  mergeClasses(
+    'font-normal flex has-[textarea]:h-auto w-full items-center rounded-md bg-background ring-offset-background',
+    'file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground',
+    'focus-within:outline-none disabled:cursor-not-allowed disabled:opacity-50 transition-colors',
+  ),
   {
     variants: {
       zSize: {
-        sm: 'h-9 px-3 py-1 text-sm',
-        default: 'h-10 px-3 py-2 text-sm',
-        lg: 'h-11 px-4 py-2 text-base',
-      },
-      zHasPrefix: {
-        true: '',
-        false: '',
-      },
-      zHasSuffix: {
-        true: '',
-        false: '',
+        sm: 'h-7.5 px-0.5 py-0 text-xs',
+        default: 'h-8.5 px-0.5 py-0 text-sm',
+        lg: 'h-9.5 px-0.5 py-0 text-base',
       },
       zHasAddonBefore: {
         true: 'border-l-0 rounded-l-none',
@@ -99,53 +120,17 @@ export const inputGroupInputVariants = cva(
         true: 'cursor-not-allowed opacity-50',
         false: '',
       },
-      zBorderless: {
-        true: 'border-0 bg-transparent shadow-none',
-        false: '',
-      },
     },
-    compoundVariants: [
-      {
-        zHasPrefix: true,
-        zSize: 'sm',
-        class: 'pl-7',
-      },
-      {
-        zHasPrefix: true,
-        zSize: 'default',
-        class: 'pl-8',
-      },
-      {
-        zHasPrefix: true,
-        zSize: 'lg',
-        class: 'pl-9',
-      },
-      {
-        zHasSuffix: true,
-        zSize: 'sm',
-        class: 'pr-12',
-      },
-      {
-        zHasSuffix: true,
-        zSize: 'default',
-        class: 'pr-14',
-      },
-      {
-        zHasSuffix: true,
-        zSize: 'lg',
-        class: 'pr-16',
-      },
-    ],
     defaultVariants: {
       zSize: 'default',
-      zHasPrefix: false,
-      zHasSuffix: false,
       zHasAddonBefore: false,
       zHasAddonAfter: false,
       zDisabled: false,
-      zBorderless: false,
     },
   },
 );
 
-export type ZardInputGroupVariants = VariantProps<typeof inputGroupVariants>;
+export type ZardInputGroupAddonAlignVariants = NonNullable<VariantProps<typeof inputGroupAddonVariants>['zAlign']>;
+export type ZardInputGroupAddonPositionVariants = NonNullable<
+  VariantProps<typeof inputGroupAddonVariants>['zPosition']
+>;

--- a/libs/zard/src/lib/components/input/doc/api.md
+++ b/libs/zard/src/lib/components/input/doc/api.md
@@ -6,8 +6,8 @@
 
 To get a customized input, just pass the following props to the directive.
 
-| Property        | Description          | Type                      | Default   |
-| --------------- | -------------------- | ------------------------- | --------- |
-| `[zSize]`       | input size           | `default\|small\|large`   | `default` |
-| `[zStatus]`     | input status         | `error\|warning\|success` | `null`    |
-| `[zBorderless]` | input without border | `boolean`                 | `false`   |
+| Property        | Description          | Type                          | Default   |
+| --------------- | -------------------- | ----------------------------- | --------- |
+| `[zSize]`       | input size           | `default \| sm \| lg`         | `default` |
+| `[zStatus]`     | input status         | `error \| warning \| success` | `null`    |
+| `[zBorderless]` | input without border | `boolean`                     | `false`   |

--- a/libs/zard/src/lib/components/input/input.directive.spec.ts
+++ b/libs/zard/src/lib/components/input/input.directive.spec.ts
@@ -11,7 +11,7 @@ import { ZardInputDirective } from './input.directive';
 })
 class TestHostComponent {}
 
-describe('InputComponent', () => {
+describe('ZardInputDirective', () => {
   let fixture: ComponentFixture<TestHostComponent>;
   let inputElement: DebugElement;
 
@@ -28,5 +28,12 @@ describe('InputComponent', () => {
   it('should create', () => {
     expect(inputElement).toBeTruthy();
     expect(inputElement.injector.get(ZardInputDirective)).toBeTruthy();
+  });
+
+  it('should disable externally', () => {
+    const directive = inputElement.injector.get(ZardInputDirective);
+    directive.disable(true);
+
+    expect(inputElement.nativeElement).toBeDisabled();
   });
 });

--- a/libs/zard/src/lib/components/input/input.directive.ts
+++ b/libs/zard/src/lib/components/input/input.directive.ts
@@ -1,29 +1,73 @@
+import { computed, Directive, effect, ElementRef, inject, input, linkedSignal, model } from '@angular/core';
+
 import type { ClassValue } from 'clsx';
 
-import { computed, Directive, ElementRef, inject, input } from '@angular/core';
-
+import {
+  inputVariants,
+  type ZardInputSizeVariants,
+  type ZardInputStatusVariants,
+  type ZardInputTypeVariants,
+} from './input.variants';
 import { mergeClasses, transform } from '../../shared/utils/utils';
-import { inputVariants, type ZardInputVariants } from './input.variants';
 
 @Directive({
   selector: 'input[z-input], textarea[z-input]',
   exportAs: 'zInput',
-  standalone: true,
   host: {
     '[class]': 'classes()',
+    '(input)': 'updateValue($event.target)',
   },
 })
 export class ZardInputDirective {
-  readonly elementRef = inject(ElementRef);
-  private readonly isTextarea = this.elementRef.nativeElement.tagName.toLowerCase() === 'textarea';
-
-  readonly zBorderless = input(false, { transform });
-  readonly zSize = input<ZardInputVariants['zSize']>('default');
-  readonly zStatus = input<ZardInputVariants['zStatus']>();
+  private readonly elementRef = inject(ElementRef);
 
   readonly class = input<ClassValue>('');
+  readonly zBorderless = input(false, { transform });
+  readonly zSize = input<ZardInputSizeVariants>('default');
+  readonly zStatus = input<ZardInputStatusVariants>();
+  readonly value = model<string>('');
+
+  readonly size = linkedSignal<ZardInputSizeVariants>(() => this.zSize());
 
   protected readonly classes = computed(() =>
-    mergeClasses(inputVariants({ zType: !this.isTextarea ? 'default' : 'textarea', zSize: this.zSize(), zStatus: this.zStatus(), zBorderless: this.zBorderless() }), this.class()),
+    mergeClasses(
+      inputVariants({
+        zType: this.getType(),
+        zSize: this.size(),
+        zStatus: this.zStatus(),
+        zBorderless: this.zBorderless(),
+      }),
+      this.class(),
+    ),
   );
+
+  constructor() {
+    effect(() => {
+      const value = this.value();
+
+      if (value !== undefined && value !== null) {
+        this.elementRef.nativeElement.value = value;
+      }
+    });
+  }
+
+  disable(b: boolean): void {
+    this.elementRef.nativeElement.disabled = b;
+  }
+
+  setDataSlot(name: string): void {
+    if (this.elementRef?.nativeElement?.dataset) {
+      this.elementRef.nativeElement.dataset.slot = name;
+    }
+  }
+
+  protected updateValue(target: EventTarget | null): void {
+    const el = target as HTMLInputElement | HTMLTextAreaElement | null;
+    this.value.set(el?.value ?? '');
+  }
+
+  getType(): ZardInputTypeVariants {
+    const isTextarea = this.elementRef.nativeElement.tagName.toLowerCase() === 'textarea';
+    return isTextarea ? 'textarea' : 'default';
+  }
 }

--- a/libs/zard/src/lib/components/input/input.variants.ts
+++ b/libs/zard/src/lib/components/input/input.variants.ts
@@ -6,14 +6,14 @@ export const inputVariants = cva('w-full', {
   variants: {
     zType: {
       default:
-        'flex rounded-md border px-4 font-normal border-input bg-transparent text-base md:text-sm file:border-0 file:text-foreground file:bg-transparent file:font-medium placeholder:text-muted-foreground outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50',
+        'flex rounded-md border px-4 font-normal border-input bg-transparent file:border-0 file:text-foreground file:bg-transparent file:font-medium placeholder:text-muted-foreground outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50',
       textarea:
-        'flex min-h-[80px] rounded-md border border-input bg-background px-3 py-2 text-base placeholder:text-muted-foreground outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+        'flex pb-2 min-h-20 h-auto rounded-md border border-input bg-background px-3 py-2 text-base placeholder:text-muted-foreground outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50',
     },
     zSize: {
-      default: 'h-10 py-2 file:max-md:py-0',
-      sm: 'h-9 file:md:py-2 file:max-md:py-1.5',
-      lg: 'h-11 py-1 file:md:py-3 file:max-md:py-2.5',
+      default: 'text-sm',
+      sm: 'text-xs',
+      lg: 'text-base',
     },
     zStatus: {
       error: 'border-destructive focus-visible:ring-destructive',
@@ -28,6 +28,13 @@ export const inputVariants = cva('w-full', {
     zType: 'default',
     zSize: 'default',
   },
+  compoundVariants: [
+    { zType: 'default', zSize: 'default', class: 'h-9 py-2 file:max-md:py-0' },
+    { zType: 'default', zSize: 'sm', class: 'h-8 file:md:py-2 file:max-md:py-1.5' },
+    { zType: 'default', zSize: 'lg', class: 'h-10 py-1 file:md:py-3 file:max-md:py-2.5' },
+  ],
 });
 
-export type ZardInputVariants = VariantProps<typeof inputVariants>;
+export type ZardInputTypeVariants = NonNullable<VariantProps<typeof inputVariants>['zType']>;
+export type ZardInputSizeVariants = NonNullable<VariantProps<typeof inputVariants>['zSize']>;
+export type ZardInputStatusVariants = NonNullable<VariantProps<typeof inputVariants>['zStatus']>;

--- a/packages/cli/src/core/themes/theme-definitions.ts
+++ b/packages/cli/src/core/themes/theme-definitions.ts
@@ -56,6 +56,17 @@ const layerBase = `
   body {
     @apply bg-background text-foreground;
   }
+
+  input[type="number"]::-webkit-inner-spin-button,
+  input[type="number"]::-webkit-outer-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
+
+  input[type="number"] {
+    -moz-appearance: textfield;
+    appearance: textfield; /* Added for general compatibility */
+  }
 }
 `;
 


### PR DESCRIPTION
## What was done? 📝

Refactored input group to reduce API, looks like shadcn/ui variant

## Screenshots or GIFs 📸

<img width="698" height="524" alt="image" src="https://github.com/user-attachments/assets/881e26a9-8644-4c99-85cf-0906889ba027" />


## Link to Issue 🔗

#288 

## Type of change 🏗

- [ ] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] Refactor (non-breaking change that improves the code or technical debt)
- [ ] Chore (none of the above, such as upgrading libraries)

## Breaking change 🚨

API changes, pay attention to addOn is addon 

## Checklist 🧐

- [x] Tested on Chrome
- [ ] Tested on Safari
- [ ] Tested on Firefox
- [x] No errors in the console


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Input-group loading state with visual loader; new text and loading demos.

* **Improvements**
  * Streamlined addon API and alignment options for input groups.
  * Refined input sizing for more consistent spacing across variants.
  * Number inputs: native spin buttons hidden and appearance unified across browsers.

* **Documentation**
  * Button size options updated — "icon" removed from listed sizes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->