### PR TITLE
Task/#336 foutc

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -2,5 +2,6 @@
   "singleQuote": true,
   "printWidth": 120,
   "arrowParens": "avoid",
+  "htmlWhitespaceSensitivity": "ignore",
   "plugins": ["prettier-plugin-tailwindcss"]
 }

--- a/apps/web/public/components/form/demo/complex.md
+++ b/apps/web/public/components/form/demo/complex.md
@@ -36,7 +36,7 @@ interface FormData {
   standalone: true,
   template: `
     <form [formGroup]="form" (ngSubmit)="handleSubmit()" class="max-w-lg space-y-6">
-      <! -- Name Fields Row - ->
+      <!-- Name Fields Row -->
       <div class="flex items-start gap-4">
         <z-form-field>
           <label z-form-label zRequired for="firstName">First Name</label>
@@ -53,7 +53,7 @@ interface FormData {
         </z-form-field>
       </div>
 
-      <! -- Email Field - ->
+      <!-- Email Field -->
       <z-form-field>
         <label z-form-label zRequired for="email">Email</label>
         <z-form-control [errorMessage]="isFieldInvalid('email') ? getEmailError() : ''">
@@ -61,7 +61,7 @@ interface FormData {
         </z-form-control>
       </z-form-field>
 
-      <! -- Phone Field - ->
+      <!-- Phone Field -->
       <z-form-field>
         <label z-form-label for="phone">Phone Number</label>
         <z-form-control helpText="Include country code if outside US">
@@ -69,7 +69,7 @@ interface FormData {
         </z-form-control>
       </z-form-field>
 
-      <! -- Country Selector - ->
+      <!-- Country Selector -->
       <z-form-field>
         <label z-form-label zRequired for="country">Country</label>
         <z-form-control [errorMessage]="isFieldInvalid('country') ? 'Please select a country' : ''">
@@ -81,7 +81,7 @@ interface FormData {
         </z-form-control>
       </z-form-field>
 
-      <! -- Company Field - ->
+      <!-- Company Field -->
       <z-form-field>
         <label z-form-label for="company">Company</label>
         <z-form-control helpText="Optional: Where do you work?">
@@ -89,7 +89,7 @@ interface FormData {
         </z-form-control>
       </z-form-field>
 
-      <! -- Message Field - ->
+      <!-- Message Field -->
       <z-form-field>
         <label z-form-label for="message">Message</label>
         <z-form-control
@@ -106,7 +106,7 @@ interface FormData {
         </z-form-control>
       </z-form-field>
 
-      <! -- Newsletter Checkbox - ->
+      <!-- Newsletter Checkbox -->
       <z-form-field>
         <z-form-control helpText="Get updates about new features and releases" class="flex flex-col">
           <div class="flex items-center space-x-2">
@@ -116,7 +116,7 @@ interface FormData {
         </z-form-control>
       </z-form-field>
 
-      <! -- Terms Checkbox - ->
+      <!-- Terms Checkbox -->
       <z-form-field>
         <z-form-control
           [errorMessage]="isFieldInvalid('terms') ? 'You must accept the terms and conditions' : ''"
@@ -129,7 +129,7 @@ interface FormData {
         </z-form-control>
       </z-form-field>
 
-      <! -- Action Buttons - ->
+      <!-- Action Buttons -->
       <div class="flex gap-2 pt-4">
         <button z-button zType="default" type="submit" [disabled]="isSubmitting()">
           {{ isSubmitting() ? 'Submitting...' : 'Submit Form' }}
@@ -137,7 +137,7 @@ interface FormData {
         <button z-button zType="outline" type="button" (click)="resetForm()">Reset</button>
       </div>
 
-      <! -- Success Message - ->
+      <!-- Success Message -->
       @if (showSuccess()) {
         <div class="rounded-md border border-green-200 bg-green-50 p-4">
           <z-form-message zType="success">✓ Form submitted successfully! We'll get back to you soon.</z-form-message>

--- a/apps/web/public/components/layout/demo/sidebar.md
+++ b/apps/web/public/components/layout/demo/sidebar.md
@@ -33,7 +33,7 @@ interface MenuItem {
   ],
   standalone: true,
   template: `
-    <! -- border and rounded-md are just for the demo purpose - ->
+    <!-- border and rounded-md are just for the demo purpose -->
     <z-layout class="overflow-hidden rounded-md border">
       <z-sidebar
         [zWidth]="250"
@@ -41,7 +41,7 @@ interface MenuItem {
         [zCollapsed]="sidebarCollapsed()"
         [zCollapsedWidth]="70"
         (zCollapsedChange)="onCollapsedChange($event)"
-        class="!p-0"
+        class="p-0!"
       >
         <nav [class]="'flex h-full flex-col overflow-hidden ' + (sidebarCollapsed() ? 'gap-1 p-1 pt-4' : 'gap-4 p-4')">
           <z-sidebar-group>
@@ -50,6 +50,7 @@ interface MenuItem {
             }
             @for (item of mainMenuItems; track item.label) {
               <button
+                type="button"
                 z-button
                 zType="ghost"
                 [class]="sidebarCollapsed() ? 'justify-center' : 'justify-start'"
@@ -71,6 +72,7 @@ interface MenuItem {
             @for (item of workspaceMenuItems; track item.label) {
               @if (item.submenu) {
                 <button
+                  type="button"
                   z-button
                   zType="ghost"
                   z-menu
@@ -90,12 +92,13 @@ interface MenuItem {
                 <ng-template #submenu>
                   <div z-menu-content class="w-48">
                     @for (subitem of item.submenu; track subitem.label) {
-                      <button z-menu-item>{{ subitem.label }}</button>
+                      <button type="button" z-menu-item>{{ subitem.label }}</button>
                     }
                   </div>
                 </ng-template>
               } @else {
                 <button
+                  type="button"
                   z-button
                   zType="ghost"
                   [class]="sidebarCollapsed() ? 'justify-center' : 'justify-start'"
@@ -135,16 +138,16 @@ interface MenuItem {
 
             <ng-template #userMenu>
               <div z-menu-content class="w-48">
-                <button z-menu-item>
+                <button type="button" z-menu-item>
                   <z-icon zType="user" class="mr-2" />
                   Profile
                 </button>
-                <button z-menu-item>
+                <button type="button" z-menu-item>
                   <z-icon zType="settings" class="mr-2" />
                   Settings
                 </button>
                 <z-divider zSpacing="sm" />
-                <button z-menu-item>
+                <button type="button" z-menu-item>
                   <z-icon zType="log-out" class="mr-2" />
                   Logout
                 </button>
@@ -154,10 +157,10 @@ interface MenuItem {
         </nav>
       </z-sidebar>
 
-      <! -- min-h-[200px] is just for the demo purpose to have a minimum height - ->
+      <!-- min-h-[200px] is just for the demo purpose to have a minimum height -->
       <z-content class="min-h-[200px]">
         <div class="flex items-center">
-          <button z-button zType="ghost" zSize="sm" class="-ml-2" (click)="toggleSidebar()">
+          <button type="button" z-button zType="ghost" zSize="sm" class="-ml-2" (click)="toggleSidebar()">
             <z-icon zType="panel-left" />
           </button>
 

--- a/apps/web/public/documentation/dark-mode/service-implementation.md
+++ b/apps/web/public/documentation/dark-mode/service-implementation.md
@@ -1,36 +1,116 @@
 ```typescript title="darkmode.service.ts" expandable="true" copyButton
-import { Injectable } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
+import { DOCUMENT, Injectable, OnDestroy, PLATFORM_ID, computed, inject, signal } from '@angular/core';
+
+export enum EThemeModes {
+  LIGHT = 'light',
+  DARK = 'dark',
+  SYSTEM = 'system',
+}
+export type ThemeOptions = EThemeModes.LIGHT | EThemeModes.DARK | EThemeModes.SYSTEM;
 
 @Injectable({
   providedIn: 'root',
 })
-export class DarkModeService {
-  private readonly storageKey = 'theme';
+export class DarkModeService implements OnDestroy {
+  private readonly document = inject(DOCUMENT);
+  private handleThemeChange = (event: MediaQueryListEvent) => this.updateMode(event.matches);
+  private readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
+  private readonly themeSignal = signal<ThemeOptions>(EThemeModes.SYSTEM);
+  private darkModeQuery?: MediaQueryList;
+
+  readonly theme = computed(() => this.themeSignal());
+
+  ngOnDestroy(): void {
+    this.handleSystemChanges(false);
+  }
 
   initTheme(): void {
-    const savedTheme = localStorage.getItem(this.storageKey);
-    const isDark = savedTheme === 'dark' || (!savedTheme && window.matchMedia('(prefers-color-scheme: dark)').matches);
+    if (!this.isBrowser) {
+      return;
+    }
 
-    this.applyTheme(isDark ? 'dark' : 'light');
+    this.applyTheme(this.getStoredTheme() ?? EThemeModes.SYSTEM);
   }
 
   toggleTheme(): void {
     const currentTheme = this.getCurrentTheme();
-    this.applyTheme(currentTheme === 'dark' ? 'light' : 'dark');
+    if (!this.isBrowser || currentTheme === EThemeModes.SYSTEM) {
+      return;
+    }
+
+    this.applyTheme(currentTheme === EThemeModes.DARK ? EThemeModes.LIGHT : EThemeModes.DARK);
   }
 
-  getCurrentTheme(): 'light' | 'dark' {
-    return (localStorage.getItem(this.storageKey) as 'light' | 'dark') || 'light';
+  activateTheme(theme: ThemeOptions): void {
+    if (!this.isBrowser) {
+      return;
+    }
+
+    this.applyTheme(theme);
   }
 
-  private applyTheme(theme: 'light' | 'dark'): void {
+  getCurrentTheme(): ThemeOptions {
+    return this.themeSignal();
+  }
+
+  private applyTheme(theme: ThemeOptions): void {
+    if (!this.isBrowser) {
+      return;
+    }
+
+    localStorage['theme'] = theme;
+    this.themeSignal.set(theme);
+    // whenever we apply theme call listener removal
+    this.handleSystemChanges(false);
+
+    this.darkModeQuery ??= this.getDarkModeQuery();
+    this.updateMode(this.isDarkMode());
+    if (theme === EThemeModes.SYSTEM) {
+      this.handleSystemChanges(true);
+    }
+  }
+
+  private getStoredTheme(): ThemeOptions | undefined {
+    const value = localStorage['theme'];
+    if (value === EThemeModes.LIGHT || value === EThemeModes.DARK || value === EThemeModes.SYSTEM) {
+      return value;
+    }
+    return undefined;
+  }
+
+  private getThemeMode(isDarkMode: boolean): EThemeModes.LIGHT | EThemeModes.DARK {
+    return isDarkMode ? EThemeModes.DARK : EThemeModes.LIGHT;
+  }
+
+  private updateMode(isDarkMode: boolean): void {
+    const themeMode = this.getThemeMode(isDarkMode);
     const html = document.documentElement;
-    const isDark = theme === 'dark';
+    html.classList.toggle('dark', isDarkMode);
+    html.setAttribute('data-theme', themeMode);
+    html.style.colorScheme = themeMode;
+  }
 
-    html.classList.toggle('dark', isDark);
-    html.setAttribute('data-theme', theme);
-    html.style.colorScheme = theme;
-    localStorage.setItem(this.storageKey, theme);
+  private getDarkModeQuery(): MediaQueryList | undefined {
+    if (!this.isBrowser) {
+      return;
+    }
+    return this.document.defaultView?.matchMedia('(prefers-color-scheme: dark)');
+  }
+
+  private isDarkMode(): boolean {
+    const isSystemDarkMode = this.darkModeQuery?.matches ?? false;
+    return (
+      localStorage['theme'] === EThemeModes.DARK || (localStorage['theme'] === EThemeModes.SYSTEM && isSystemDarkMode)
+    );
+  }
+
+  private handleSystemChanges(addListener: boolean): void {
+    if (addListener) {
+      this.darkModeQuery?.addEventListener('change', this.handleThemeChange);
+    } else {
+      this.darkModeQuery?.removeEventListener('change', this.handleThemeChange);
+    }
   }
 }
 ```

--- a/apps/web/public/installation/manual/calendar.md
+++ b/apps/web/public/installation/manual/calendar.md
@@ -455,7 +455,7 @@ import { mergeClasses } from '../../shared/utils/utils';
   standalone: true,
   template: `
     <div #gridContainer>
-      <! -- Weekdays Header - ->
+      <!-- Weekdays Header -->
       <div class="grid w-fit grid-cols-7 text-center" role="row">
         @for (weekday of weekdays; track $index) {
           <div [class]="weekdayClasses()" role="columnheader">
@@ -464,11 +464,12 @@ import { mergeClasses } from '../../shared/utils/utils';
         }
       </div>
 
-      <! -- Calendar Days Grid - ->
+      <!-- Calendar Days Grid -->
       <div class="mt-2 grid w-fit auto-rows-min grid-cols-7 gap-0" role="rowgroup">
         @for (day of calendarDays(); track day.date.getTime(); let i = $index) {
           <div [class]="dayContainerClasses()" role="gridcell">
             <button
+              type="button"
               [id]="getDayId(i)"
               [class]="dayButtonClasses(day)"
               (click)="onDayClick(day.date, i)"
@@ -738,6 +739,7 @@ import { ZardSelectComponent } from '../select/select.component';
   template: `
     <div [class]="navClasses()">
       <button
+        type="button"
         z-button
         zType="ghost"
         zSize="sm"
@@ -749,9 +751,9 @@ import { ZardSelectComponent } from '../select/select.component';
         <z-icon zType="chevron-left" />
       </button>
 
-      <! -- Month and Year Selectors - ->
+      <!-- Month and Year Selectors -->
       <div class="flex items-center space-x-2">
-        <! -- Month Select - ->
+        <!-- Month Select -->
         <z-select
           class="min-w-20"
           [zValue]="currentMonth()"
@@ -763,7 +765,7 @@ import { ZardSelectComponent } from '../select/select.component';
           }
         </z-select>
 
-        <! -- Year Select - ->
+        <!-- Year Select -->
         <z-select
           class="min-w-21"
           [zValue]="currentYear()"
@@ -777,6 +779,7 @@ import { ZardSelectComponent } from '../select/select.component';
       </div>
 
       <button
+        type="button"
         z-button
         zType="ghost"
         zSize="sm"

--- a/apps/web/public/installation/manual/dropdown.md
+++ b/apps/web/public/installation/manual/dropdown.md
@@ -9,7 +9,6 @@ import {
   Component,
   computed,
   ElementRef,
-  HostListener,
   inject,
   input,
   type OnDestroy,
@@ -33,7 +32,7 @@ import { mergeClasses, transform } from '../../shared/utils/utils';
   imports: [OverlayModule],
   standalone: true,
   template: `
-    <! -- Dropdown Trigger - ->
+    <!-- Dropdown Trigger -->
     <div
       class="trigger-container"
       (click)="toggle()"
@@ -44,7 +43,7 @@ import { mergeClasses, transform } from '../../shared/utils/utils';
       <ng-content select="[dropdown-trigger]" />
     </div>
 
-    <! -- Template for overlay content - ->
+    <!-- Template for overlay content -->
     <ng-template #dropdownTemplate>
       <div
         [class]="contentClasses()"
@@ -62,6 +61,7 @@ import { mergeClasses, transform } from '../../shared/utils/utils';
   host: {
     '[attr.data-state]': 'isOpen() ? "open" : "closed"',
     class: 'relative inline-block text-left',
+    '(document:click)': 'onDocumentClick($event)',
   },
   exportAs: 'zDropdownMenu',
 })
@@ -97,7 +97,6 @@ export class ZardDropdownMenuComponent implements OnInit, OnDestroy {
     this.destroyOverlay();
   }
 
-  @HostListener('document:click', ['$event'])
   onDocumentClick(event: Event) {
     if (!this.elementRef.nativeElement.contains(event.target as Node)) {
       this.close();

--- a/apps/web/public/installation/manual/icon.md
+++ b/apps/web/public/installation/manual/icon.md
@@ -145,6 +145,7 @@ import {
   SquareLibrary,
   Star,
   Sun,
+  SunMoon,
   Tablet,
   Tag,
   Terminal,
@@ -244,6 +245,7 @@ export const ZARD_ICONS = {
   'list-filter-plus': ListFilterPlus,
   trash: Trash2,
   tag: Tag,
+  'sun-moon': SunMoon,
 } as const satisfies Record<string, LucideIconData>;
 
 export declare type ZardIcon = keyof typeof ZARD_ICONS | LucideIconData;

--- a/apps/web/src/app/core/layouts/documentation/documentation.layout.ts
+++ b/apps/web/src/app/core/layouts/documentation/documentation.layout.ts
@@ -5,7 +5,7 @@ import { FooterComponent } from '@doc/domain/components/footer/footer.component'
 import { HeaderComponent } from '@doc/domain/components/header/header.component';
 import { SidebarComponent } from '@doc/domain/components/sidebar/sidebar.component';
 import { environment } from '@doc/env/environment';
-import { DarkModeService } from '@doc/shared/services/darkmode.service';
+import { DarkModeService, EThemeModes, ThemeOptions } from '@doc/shared/services/darkmode.service';
 
 import { ZardToastComponent } from '@zard/components/toast/toast.component';
 
@@ -34,7 +34,7 @@ export class DocumentationLayout {
   private readonly destroyRef = inject(DestroyRef);
   readonly isDevEnv = !environment.production;
 
-  private readonly themeSignal = signal<'light' | 'dark'>('light');
+  private readonly themeSignal = signal<ThemeOptions>(EThemeModes.LIGHT);
   readonly currentTheme = computed(() => this.themeSignal());
 
   constructor() {

--- a/apps/web/src/app/domain/components/header/header.component.html
+++ b/apps/web/src/app/domain/components/header/header.component.html
@@ -41,28 +41,42 @@
           <span class="sr-only">Toggle layout</span>
         </button>
         <z-divider zOrientation="vertical" zSpacing="none" class="hidden h-4! lg:block"></z-divider>
-        <button z-button zType="ghost" zSize="sm" (click)="toggleTheme()">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="24"
-            height="24"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            class="size-4.5"
+        @let theme = currentTheme();
+        <z-button-group>
+          <button
+            z-button
+            zType="ghost"
+            zSize="sm"
+            [disabled]="theme === EThemeModes.SYSTEM"
+            [aria-pressed]="theme === EThemeModes.SYSTEM"
+            (click)="activateTheme(EThemeModes.SYSTEM)"
           >
-            <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
-            <path d="M12 12m-9 0a9 9 0 1 0 18 0a9 9 0 1 0 -18 0"></path>
-            <path d="M12 3l0 18"></path>
-            <path d="M12 9l4.65 -4.65"></path>
-            <path d="M12 14.3l7.37 -7.37"></path>
-            <path d="M12 19.6l8.85 -8.85"></path>
-          </svg>
-          <span class="sr-only">Toggle theme</span>
-        </button>
+            <z-icon zType="sun-moon" />
+            <span class="sr-only">Use system theme</span>
+          </button>
+          <button
+            z-button
+            zType="ghost"
+            zSize="sm"
+            [disabled]="theme === EThemeModes.LIGHT"
+            [aria-pressed]="theme === EThemeModes.LIGHT"
+            (click)="activateTheme(EThemeModes.LIGHT)"
+          >
+            <z-icon zType="sun" />
+            <span class="sr-only">Light theme</span>
+          </button>
+          <button
+            z-button
+            zType="ghost"
+            zSize="sm"
+            [disabled]="theme === EThemeModes.DARK"
+            [aria-pressed]="theme === EThemeModes.DARK"
+            (click)="activateTheme(EThemeModes.DARK)"
+          >
+            <z-icon zType="moon" />
+            <span class="sr-only">Dark theme</span>
+          </button>
+        </z-button-group>
       </aside>
     </menu>
   </nav>

--- a/apps/web/src/app/domain/components/header/header.component.ts
+++ b/apps/web/src/app/domain/components/header/header.component.ts
@@ -9,12 +9,14 @@ import { LayoutService } from '@doc/shared/services/layout.service';
 
 import { ZardBadgeComponent } from '@zard/components/badge/badge.component';
 import { ZardButtonComponent } from '@zard/components/button/button.component';
+import { ZardButtonGroupComponent } from '@zard/components/button-group/button-group.component';
 import { ZardDividerComponent } from '@zard/components/divider/divider.component';
+import { ZardIconComponent } from '@zard/components/icon/icon.component';
 
 import { environment } from '../../../../environments/environment';
 import { SOCIAL_MEDIAS } from '../../../shared/constants/medias.constant';
 import { HEADER_PATHS } from '../../../shared/constants/routes.constant';
-import { DarkModeService } from '../../../shared/services/darkmode.service';
+import { DarkModeService, ThemeOptions, EThemeModes } from '../../../shared/services/darkmode.service';
 import { GithubService } from '../../../shared/services/github.service';
 import { DocResearcherComponent } from '../doc-researcher/doc-researcher.component';
 import { MobileMenuComponent } from '../mobile-nav/mobile-nav.component';
@@ -23,7 +25,18 @@ import { MobileMenuComponent } from '../mobile-nav/mobile-nav.component';
   selector: 'z-header',
   templateUrl: './header.component.html',
   standalone: true,
-  imports: [RouterModule, ZardButtonComponent, ZardBadgeComponent, MobileMenuComponent, ZardDividerComponent, AsyncPipe, DocResearcherComponent, LucideAngularModule],
+  imports: [
+    RouterModule,
+    ZardButtonComponent,
+    ZardButtonGroupComponent,
+    ZardIconComponent,
+    ZardBadgeComponent,
+    MobileMenuComponent,
+    ZardDividerComponent,
+    AsyncPipe,
+    DocResearcherComponent,
+    LucideAngularModule,
+  ],
 })
 export class HeaderComponent {
   readonly docResearcher = viewChild.required(DocResearcherComponent);
@@ -36,13 +49,11 @@ export class HeaderComponent {
   private readonly darkmodeService = inject(DarkModeService);
   private readonly layoutService = inject(LayoutService);
   readonly $repoStars: Observable<number> = this.githubService.getStarsCount();
+  protected readonly currentTheme = this.darkmodeService.theme;
+  protected readonly EThemeModes = EThemeModes;
 
-  toggleTheme(): void {
-    this.darkmodeService.toggleTheme();
-  }
-
-  getCurrentTheme(): 'light' | 'dark' {
-    return this.darkmodeService.getCurrentTheme();
+  activateTheme(theme: ThemeOptions): void {
+    this.darkmodeService.activateTheme(theme);
   }
 
   toggleLayout(): void {

--- a/apps/web/src/app/domain/pages/dark-mode/dark-mode.page.html
+++ b/apps/web/src/app/domain/pages/dark-mode/dark-mode.page.html
@@ -1,4 +1,9 @@
-<z-content [navigationConfig]="navigationConfig" [activeAnchor]="activeAnchor" scrollSpy (scrollSpyChange)="activeAnchor = $event">
+<z-content
+  [navigationConfig]="navigationConfig"
+  [activeAnchor]="activeAnchor"
+  scrollSpy
+  (scrollSpyChange)="activeAnchor = $event"
+>
   <!-- Overview Section -->
   <z-doc-heading
     title="Dark Mode"
@@ -8,27 +13,27 @@
   />
 
   <div class="flex flex-col gap-6">
-    <p class="text-sm sm:text-base text-muted-foreground leading-relaxed">
+    <p class="text-muted-foreground text-sm leading-relaxed sm:text-base">
       ZardUI implements a robust dark mode system using
-      <code class="bg-muted px-2 py-1 rounded text-xs sm:text-sm font-mono">&#64;custom-variant dark</code>
+      <code class="bg-muted rounded px-2 py-1 font-mono text-xs sm:text-sm">&#64;custom-variant dark</code>
       from TailwindCSS v4 combined with an Angular
-      <code class="bg-muted px-2 py-1 rounded text-xs sm:text-sm font-mono">DarkModeService</code>
+      <code class="bg-muted rounded px-2 py-1 font-mono text-xs sm:text-sm">DarkModeService</code>
       for state management and persistence.
     </p>
 
     <z-alert
       zTitle="Current Implementation Status"
       zDescription="Currently, dark mode works via CSS class variations. In the future, we plan to add a CLI option for automatic service installation."
-    >
-    </z-alert>
+    ></z-alert>
   </div>
 
   <!-- Current Implementation Section -->
   <section class="flex flex-col gap-8 sm:gap-10" scrollSpyItem="current-implementation" id="current-implementation">
     <div class="flex flex-col gap-6">
-      <h2 class="text-xl sm:text-2xl lg:text-3xl font-bold tracking-tight">Current Implementation</h2>
-      <p class="text-base sm:text-lg text-muted-foreground leading-relaxed">
-        The current system works by applying the <code class="bg-muted px-2 py-1 rounded text-xs font-mono">.dark</code>
+      <h2 class="text-xl font-bold tracking-tight sm:text-2xl lg:text-3xl">Current Implementation</h2>
+      <p class="text-muted-foreground text-base leading-relaxed sm:text-lg">
+        The current system works by applying the
+        <code class="bg-muted rounded px-2 py-1 font-mono text-xs">.dark</code>
         class to the root HTML element, activating all dark style variations defined in the components.
       </p>
     </div>
@@ -37,8 +42,8 @@
   <!-- Service Details Section -->
   <section class="flex flex-col gap-8 sm:gap-10" scrollSpyItem="service-details" id="service-details">
     <div class="flex flex-col gap-6">
-      <h2 class="text-xl sm:text-2xl lg:text-3xl font-bold tracking-tight">DarkMode Service</h2>
-      <p class="text-base sm:text-lg text-muted-foreground leading-relaxed">
+      <h2 class="text-xl font-bold tracking-tight sm:text-2xl lg:text-3xl">DarkMode Service</h2>
+      <p class="text-muted-foreground text-base leading-relaxed sm:text-lg">
         The core of the system is an Angular service that manages theme state, persistence, and CSS class application.
       </p>
     </div>
@@ -49,20 +54,21 @@
   <!-- Usage in App Section -->
   <section class="flex flex-col gap-8 sm:gap-10" scrollSpyItem="usage-in-app" id="usage-in-app">
     <div class="flex flex-col gap-6">
-      <h2 class="text-xl sm:text-2xl lg:text-3xl font-bold tracking-tight">Usage in Application</h2>
-      <p class="text-base sm:text-lg text-muted-foreground leading-relaxed">
-        See how the service is used in the AppComponent for initialization and in the HeaderComponent for toggle control.
+      <h2 class="text-xl font-bold tracking-tight sm:text-2xl lg:text-3xl">Usage in Application</h2>
+      <p class="text-muted-foreground text-base leading-relaxed sm:text-lg">
+        See how the service is used in the AppComponent for initialization and in the HeaderComponent for toggle
+        control.
       </p>
     </div>
 
     <div class="flex flex-col gap-6">
       <div>
-        <h3 class="text-base sm:text-lg font-semibold mb-6">App Component</h3>
+        <h3 class="mb-6 text-base font-semibold sm:text-lg">App Component</h3>
         <z-markdown-renderer markdownUrl="/documentation/dark-mode/app-usage.md"></z-markdown-renderer>
       </div>
 
       <div>
-        <h3 class="text-base sm:text-lg font-semibold mb-6">Header Component</h3>
+        <h3 class="mb-6 text-base font-semibold sm:text-lg">Header Component</h3>
         <z-markdown-renderer markdownUrl="/documentation/dark-mode/header-usage.md"></z-markdown-renderer>
       </div>
     </div>
@@ -71,32 +77,39 @@
   <!-- Interactive Demo Section -->
   <section class="flex flex-col gap-8 sm:gap-10" scrollSpyItem="demo" id="demo">
     <div class="flex flex-col gap-6">
-      <h2 class="text-xl sm:text-2xl lg:text-3xl font-bold tracking-tight">Interactive Demo</h2>
-      <p class="text-base sm:text-lg text-muted-foreground leading-relaxed">Test the dark mode system in action and see how components react to theme changes.</p>
+      <h2 class="text-xl font-bold tracking-tight sm:text-2xl lg:text-3xl">Interactive Demo</h2>
+      <p class="text-muted-foreground text-base leading-relaxed sm:text-lg">
+        Test the dark mode system in action and see how components react to theme changes.
+      </p>
     </div>
 
     <z-card class="p-6">
-      <div class="flex items-center justify-between mb-6">
+      <div class="mb-6 flex items-center justify-between">
         <div>
           <h3 class="text-lg font-semibold">Theme Control</h3>
-          <p class="text-sm text-muted-foreground">Current theme: <strong>{{ getCurrentTheme() }}</strong></p>
+          <p class="text-muted-foreground text-sm">
+            Current theme:
+            <strong>{{ darkModeService.theme() }}</strong>
+          </p>
         </div>
-        <z-button (click)="toggleTheme()" variant="outline"> {{ getCurrentTheme() === 'dark' ? '☀️ Light Mode' : '🌙 Dark Mode' }} </z-button>
+        <z-button variant="outline">
+          {{ darkModeService.theme() === EThemeModes.DARK ? '☀️ Light Mode' : '🌙 Dark Mode' }}
+        </z-button>
       </div>
 
-      <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
-        <div class="p-4 border rounded-lg bg-background">
-          <h4 class="font-medium mb-2">Card Example</h4>
-          <p class="text-sm text-muted-foreground">This card automatically changes with the theme.</p>
+      <div class="grid grid-cols-1 gap-4 md:grid-cols-3">
+        <div class="bg-background rounded-lg border p-4">
+          <h4 class="mb-2 font-medium">Card Example</h4>
+          <p class="text-muted-foreground text-sm">This card automatically changes with the theme.</p>
         </div>
 
-        <div class="p-4 border rounded-lg bg-muted/50">
-          <h4 class="font-medium mb-2">Muted Background</h4>
-          <p class="text-sm text-muted-foreground">Background with responsive opacity.</p>
+        <div class="bg-muted/50 rounded-lg border p-4">
+          <h4 class="mb-2 font-medium">Muted Background</h4>
+          <p class="text-muted-foreground text-sm">Background with responsive opacity.</p>
         </div>
 
-        <div class="p-4 border rounded-lg bg-primary text-primary-foreground">
-          <h4 class="font-medium mb-2">Primary Colors</h4>
+        <div class="bg-primary text-primary-foreground rounded-lg border p-4">
+          <h4 class="mb-2 font-medium">Primary Colors</h4>
           <p class="text-sm opacity-90">Primary colors adapted to theme.</p>
         </div>
       </div>

--- a/apps/web/src/app/domain/pages/dark-mode/dark-mode.page.ts
+++ b/apps/web/src/app/domain/pages/dark-mode/dark-mode.page.ts
@@ -1,4 +1,4 @@
-import { Component, inject, type OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, type OnInit } from '@angular/core';
 
 import { SeoService } from '@doc/shared/services/seo.service';
 
@@ -6,7 +6,7 @@ import { ZardAlertComponent } from '@zard/components/alert/alert.component';
 import { ZardButtonComponent } from '@zard/components/button/button.component';
 import { ZardCardComponent } from '@zard/components/card/card.component';
 
-import { DarkModeService } from '../../../shared/services/darkmode.service';
+import { DarkModeService, EThemeModes } from '../../../shared/services/darkmode.service';
 import { DocContentComponent } from '../../components/doc-content/doc-content.component';
 import { DocHeadingComponent } from '../../components/doc-heading/doc-heading.component';
 import { NavigationConfig } from '../../components/dynamic-anchor/dynamic-anchor.component';
@@ -16,7 +16,6 @@ import { ScrollSpyDirective } from '../../directives/scroll-spy.directive';
 
 @Component({
   selector: 'z-darkmode',
-  standalone: true,
   imports: [
     DocContentComponent,
     DocHeadingComponent,
@@ -28,12 +27,15 @@ import { ScrollSpyDirective } from '../../directives/scroll-spy.directive';
     ZardAlertComponent,
   ],
   templateUrl: './dark-mode.page.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DarkmodePage implements OnInit {
   activeAnchor?: string;
 
-  private readonly darkModeService = inject(DarkModeService);
   private readonly seoService = inject(SeoService);
+
+  protected readonly darkModeService = inject(DarkModeService);
+  protected readonly EThemeModes = EThemeModes;
 
   readonly navigationConfig: NavigationConfig = {
     items: [
@@ -44,14 +46,6 @@ export class DarkmodePage implements OnInit {
       { id: 'demo', label: 'Interactive Demo', type: 'custom' },
     ],
   };
-
-  getCurrentTheme(): 'light' | 'dark' {
-    return this.darkModeService.getCurrentTheme();
-  }
-
-  toggleTheme(): void {
-    this.darkModeService.toggleTheme();
-  }
 
   ngOnInit(): void {
     this.seoService.setDocsSeo('Dark Mode', 'Adding dark mode to your site.', '/docs/dark-mode', 'og-darkmode.jpg');

--- a/apps/web/src/app/shared/services/darkmode.service.ts
+++ b/apps/web/src/app/shared/services/darkmode.service.ts
@@ -1,56 +1,114 @@
 import { isPlatformBrowser } from '@angular/common';
-import { Injectable, PLATFORM_ID, inject, signal } from '@angular/core';
+import { DOCUMENT, Injectable, OnDestroy, PLATFORM_ID, computed, inject, signal } from '@angular/core';
+
+export enum EThemeModes {
+  LIGHT = 'light',
+  DARK = 'dark',
+  SYSTEM = 'system',
+}
+export type ThemeOptions = EThemeModes.LIGHT | EThemeModes.DARK | EThemeModes.SYSTEM;
 
 @Injectable({
   providedIn: 'root',
 })
-export class DarkModeService {
-  private readonly platformId = inject(PLATFORM_ID);
-  private readonly isBrowser = isPlatformBrowser(this.platformId);
-  private readonly storageKey = 'theme';
-  private readonly themeSignal = signal<'light' | 'dark'>('light');
+export class DarkModeService implements OnDestroy {
+  private readonly document = inject(DOCUMENT);
+  private handleThemeChange = (event: MediaQueryListEvent) => this.updateMode(event.matches);
+  private readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
+  private readonly themeSignal = signal<ThemeOptions>(EThemeModes.SYSTEM);
+  private darkModeQuery?: MediaQueryList;
+
+  readonly theme = computed(() => this.themeSignal());
+
+  ngOnDestroy(): void {
+    this.handleSystemChanges(false);
+  }
 
   initTheme(): void {
     if (!this.isBrowser) {
       return;
     }
 
-    const savedTheme = localStorage.getItem(this.storageKey);
-    const isDark = savedTheme === 'dark' || (!savedTheme && window.matchMedia('(prefers-color-scheme: dark)').matches);
-
-    this.applyTheme(isDark ? 'dark' : 'light');
+    this.applyTheme(this.getStoredTheme() ?? EThemeModes.SYSTEM);
   }
 
   toggleTheme(): void {
+    const currentTheme = this.getCurrentTheme();
+    if (!this.isBrowser || currentTheme === EThemeModes.SYSTEM) {
+      return;
+    }
+
+    this.applyTheme(currentTheme === EThemeModes.DARK ? EThemeModes.LIGHT : EThemeModes.DARK);
+  }
+
+  activateTheme(theme: ThemeOptions): void {
     if (!this.isBrowser) {
       return;
     }
 
-    const currentTheme = this.getCurrentTheme();
-    this.applyTheme(currentTheme === 'dark' ? 'light' : 'dark');
+    this.applyTheme(theme);
   }
 
-  getCurrentTheme(): 'light' | 'dark' {
+  getCurrentTheme(): ThemeOptions {
     return this.themeSignal();
   }
 
-  get theme() {
-    return this.themeSignal.asReadonly();
-  }
-
-  private applyTheme(theme: 'light' | 'dark'): void {
+  private applyTheme(theme: ThemeOptions): void {
     if (!this.isBrowser) {
       return;
     }
 
-    const html = document.documentElement;
-    const isDark = theme === 'dark';
-
-    html.classList.toggle('dark', isDark);
-    html.setAttribute('data-theme', theme);
-    html.style.colorScheme = theme;
-    localStorage.setItem(this.storageKey, theme);
-
+    localStorage['theme'] = theme;
     this.themeSignal.set(theme);
+    // whenever we apply theme call listener removal
+    this.handleSystemChanges(false);
+
+    this.darkModeQuery ??= this.getDarkModeQuery();
+    this.updateMode(this.isDarkMode());
+    if (theme === EThemeModes.SYSTEM) {
+      this.handleSystemChanges(true);
+    }
+  }
+
+  private getStoredTheme(): ThemeOptions | undefined {
+    const value = localStorage['theme'];
+    if (value === EThemeModes.LIGHT || value === EThemeModes.DARK || value === EThemeModes.SYSTEM) {
+      return value;
+    }
+    return undefined;
+  }
+
+  private getThemeMode(isDarkMode: boolean): EThemeModes.LIGHT | EThemeModes.DARK {
+    return isDarkMode ? EThemeModes.DARK : EThemeModes.LIGHT;
+  }
+
+  private updateMode(isDarkMode: boolean): void {
+    const themeMode = this.getThemeMode(isDarkMode);
+    const html = document.documentElement;
+    html.classList.toggle('dark', isDarkMode);
+    html.setAttribute('data-theme', themeMode);
+    html.style.colorScheme = themeMode;
+  }
+
+  private getDarkModeQuery(): MediaQueryList | undefined {
+    if (!this.isBrowser) {
+      return;
+    }
+    return this.document.defaultView?.matchMedia('(prefers-color-scheme: dark)');
+  }
+
+  private isDarkMode(): boolean {
+    const isSystemDarkMode = this.darkModeQuery?.matches ?? false;
+    return (
+      localStorage['theme'] === EThemeModes.DARK || (localStorage['theme'] === EThemeModes.SYSTEM && isSystemDarkMode)
+    );
+  }
+
+  private handleSystemChanges(addListener: boolean): void {
+    if (addListener) {
+      this.darkModeQuery?.addEventListener('change', this.handleThemeChange);
+    } else {
+      this.darkModeQuery?.removeEventListener('change', this.handleThemeChange);
+    }
   }
 }

--- a/apps/web/src/index.html
+++ b/apps/web/src/index.html
@@ -65,18 +65,15 @@
 
         try {
           const theme = localStorage.theme;
+          const prefersDark = window.matchMedia?.('(prefers-color-scheme: dark)').matches ?? false;
 
-          const isDark =
-            localStorage.theme === 'dark' ||
-            !('theme' in localStorage) ||
-            (localStorage.theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches);
-
-          if (isDark) {
-            html.classList.add('dark-theme');
-            html.classList.toggle('dark', isDark);
-            html.setAttribute('data-theme', theme);
-            html.style.colorScheme = theme;
-          }
+          const isSystem = theme === 'system' || !('theme' in localStorage);
+          const isDark = theme === 'dark' || (isSystem && prefersDark);
+          const resolvedTheme = isDark ? 'dark' : 'light';
+          html.classList.toggle('dark', isDark);
+          html.classList.toggle('dark-theme', isDark);
+          html.setAttribute('data-theme', theme ?? 'system');
+          html.style.colorScheme = resolvedTheme;
         } catch (_) {}
       })();
     </script>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -299,19 +299,19 @@ code [data-highlighted-chars] {
 }
 
 table.api-table--component tbody td:first-child code {
-  @apply !border-blue-500/20 !bg-blue-500/10 !text-blue-600 dark:!text-blue-400;
+  @apply border-blue-500/20! bg-blue-500/10! text-blue-600! dark:text-blue-400!;
 }
 
 table.api-table--directive tbody td:first-child code {
-  @apply !border-green-500/20 !bg-green-500/10 !text-green-600 dark:!text-green-400;
+  @apply border-green-500/20! bg-green-500/10! text-green-600! dark:text-green-400!;
 }
 
 table.api-table--service tbody td:first-child code {
-  @apply !border-amber-500/20 !bg-amber-500/10 !text-amber-600 dark:!text-amber-400;
+  @apply border-amber-500/20! bg-amber-500/10! text-amber-600! dark:text-amber-400!;
 }
 
 table.api-table--pipe tbody td:first-child code {
-  @apply !border-purple-500/20 !bg-purple-500/10 !text-purple-600 dark:!text-purple-400;
+  @apply border-purple-500/20! bg-purple-500/10! text-purple-600! dark:text-purple-400!;
 }
 
 .embla {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -110,6 +110,6 @@ export default [
   {
     files: ['**/*.html'],
     // Override or add rules here
-    rules: {},
+    rules: { '@stylistic/spaced-comment': 'off' },
   },
 ];

--- a/libs/zard/src/lib/components/calendar/calendar-grid.component.ts
+++ b/libs/zard/src/lib/components/calendar/calendar-grid.component.ts
@@ -21,7 +21,7 @@ import { mergeClasses } from '../../shared/utils/utils';
   standalone: true,
   template: `
     <div #gridContainer>
-      <! -- Weekdays Header - ->
+      <!-- Weekdays Header -->
       <div class="grid w-fit grid-cols-7 text-center" role="row">
         @for (weekday of weekdays; track $index) {
           <div [class]="weekdayClasses()" role="columnheader">
@@ -30,11 +30,12 @@ import { mergeClasses } from '../../shared/utils/utils';
         }
       </div>
 
-      <! -- Calendar Days Grid - ->
+      <!-- Calendar Days Grid -->
       <div class="mt-2 grid w-fit auto-rows-min grid-cols-7 gap-0" role="rowgroup">
         @for (day of calendarDays(); track day.date.getTime(); let i = $index) {
           <div [class]="dayContainerClasses()" role="gridcell">
             <button
+              type="button"
               [id]="getDayId(i)"
               [class]="dayButtonClasses(day)"
               (click)="onDayClick(day.date, i)"

--- a/libs/zard/src/lib/components/calendar/calendar-navigation.component.ts
+++ b/libs/zard/src/lib/components/calendar/calendar-navigation.component.ts
@@ -14,6 +14,7 @@ import { ZardSelectComponent } from '../select/select.component';
   template: `
     <div [class]="navClasses()">
       <button
+        type="button"
         z-button
         zType="ghost"
         zSize="sm"
@@ -25,9 +26,9 @@ import { ZardSelectComponent } from '../select/select.component';
         <z-icon zType="chevron-left" />
       </button>
 
-      <! -- Month and Year Selectors - ->
+      <!-- Month and Year Selectors -->
       <div class="flex items-center space-x-2">
-        <! -- Month Select - ->
+        <!-- Month Select -->
         <z-select
           class="min-w-20"
           [zValue]="currentMonth()"
@@ -39,7 +40,7 @@ import { ZardSelectComponent } from '../select/select.component';
           }
         </z-select>
 
-        <! -- Year Select - ->
+        <!-- Year Select -->
         <z-select
           class="min-w-21"
           [zValue]="currentYear()"
@@ -53,6 +54,7 @@ import { ZardSelectComponent } from '../select/select.component';
       </div>
 
       <button
+        type="button"
         z-button
         zType="ghost"
         zSize="sm"

--- a/libs/zard/src/lib/components/dropdown/dropdown.component.ts
+++ b/libs/zard/src/lib/components/dropdown/dropdown.component.ts
@@ -6,7 +6,6 @@ import {
   Component,
   computed,
   ElementRef,
-  HostListener,
   inject,
   input,
   type OnDestroy,
@@ -30,7 +29,7 @@ import { mergeClasses, transform } from '../../shared/utils/utils';
   imports: [OverlayModule],
   standalone: true,
   template: `
-    <! -- Dropdown Trigger - ->
+    <!-- Dropdown Trigger -->
     <div
       class="trigger-container"
       (click)="toggle()"
@@ -41,7 +40,7 @@ import { mergeClasses, transform } from '../../shared/utils/utils';
       <ng-content select="[dropdown-trigger]" />
     </div>
 
-    <! -- Template for overlay content - ->
+    <!-- Template for overlay content -->
     <ng-template #dropdownTemplate>
       <div
         [class]="contentClasses()"
@@ -59,6 +58,7 @@ import { mergeClasses, transform } from '../../shared/utils/utils';
   host: {
     '[attr.data-state]': 'isOpen() ? "open" : "closed"',
     class: 'relative inline-block text-left',
+    '(document:click)': 'onDocumentClick($event)',
   },
   exportAs: 'zDropdownMenu',
 })
@@ -94,7 +94,6 @@ export class ZardDropdownMenuComponent implements OnInit, OnDestroy {
     this.destroyOverlay();
   }
 
-  @HostListener('document:click', ['$event'])
   onDocumentClick(event: Event) {
     if (!this.elementRef.nativeElement.contains(event.target as Node)) {
       this.close();

--- a/libs/zard/src/lib/components/form/demo/complex.ts
+++ b/libs/zard/src/lib/components/form/demo/complex.ts
@@ -35,7 +35,7 @@ interface FormData {
   standalone: true,
   template: `
     <form [formGroup]="form" (ngSubmit)="handleSubmit()" class="max-w-lg space-y-6">
-      <! -- Name Fields Row - ->
+      <!-- Name Fields Row -->
       <div class="flex items-start gap-4">
         <z-form-field>
           <label z-form-label zRequired for="firstName">First Name</label>
@@ -52,7 +52,7 @@ interface FormData {
         </z-form-field>
       </div>
 
-      <! -- Email Field - ->
+      <!-- Email Field -->
       <z-form-field>
         <label z-form-label zRequired for="email">Email</label>
         <z-form-control [errorMessage]="isFieldInvalid('email') ? getEmailError() : ''">
@@ -60,7 +60,7 @@ interface FormData {
         </z-form-control>
       </z-form-field>
 
-      <! -- Phone Field - ->
+      <!-- Phone Field -->
       <z-form-field>
         <label z-form-label for="phone">Phone Number</label>
         <z-form-control helpText="Include country code if outside US">
@@ -68,7 +68,7 @@ interface FormData {
         </z-form-control>
       </z-form-field>
 
-      <! -- Country Selector - ->
+      <!-- Country Selector -->
       <z-form-field>
         <label z-form-label zRequired for="country">Country</label>
         <z-form-control [errorMessage]="isFieldInvalid('country') ? 'Please select a country' : ''">
@@ -80,7 +80,7 @@ interface FormData {
         </z-form-control>
       </z-form-field>
 
-      <! -- Company Field - ->
+      <!-- Company Field -->
       <z-form-field>
         <label z-form-label for="company">Company</label>
         <z-form-control helpText="Optional: Where do you work?">
@@ -88,7 +88,7 @@ interface FormData {
         </z-form-control>
       </z-form-field>
 
-      <! -- Message Field - ->
+      <!-- Message Field -->
       <z-form-field>
         <label z-form-label for="message">Message</label>
         <z-form-control
@@ -105,7 +105,7 @@ interface FormData {
         </z-form-control>
       </z-form-field>
 
-      <! -- Newsletter Checkbox - ->
+      <!-- Newsletter Checkbox -->
       <z-form-field>
         <z-form-control helpText="Get updates about new features and releases" class="flex flex-col">
           <div class="flex items-center space-x-2">
@@ -115,7 +115,7 @@ interface FormData {
         </z-form-control>
       </z-form-field>
 
-      <! -- Terms Checkbox - ->
+      <!-- Terms Checkbox -->
       <z-form-field>
         <z-form-control
           [errorMessage]="isFieldInvalid('terms') ? 'You must accept the terms and conditions' : ''"
@@ -128,7 +128,7 @@ interface FormData {
         </z-form-control>
       </z-form-field>
 
-      <! -- Action Buttons - ->
+      <!-- Action Buttons -->
       <div class="flex gap-2 pt-4">
         <button z-button zType="default" type="submit" [disabled]="isSubmitting()">
           {{ isSubmitting() ? 'Submitting...' : 'Submit Form' }}
@@ -136,7 +136,7 @@ interface FormData {
         <button z-button zType="outline" type="button" (click)="resetForm()">Reset</button>
       </div>
 
-      <! -- Success Message - ->
+      <!-- Success Message -->
       @if (showSuccess()) {
         <div class="rounded-md border border-green-200 bg-green-50 p-4">
           <z-form-message zType="success">✓ Form submitted successfully! We'll get back to you soon.</z-form-message>

--- a/libs/zard/src/lib/components/icon/icons.ts
+++ b/libs/zard/src/lib/components/icon/icons.ts
@@ -70,6 +70,7 @@ import {
   SquareLibrary,
   Star,
   Sun,
+  SunMoon,
   Tablet,
   Tag,
   Terminal,
@@ -169,6 +170,7 @@ export const ZARD_ICONS = {
   'list-filter-plus': ListFilterPlus,
   trash: Trash2,
   tag: Tag,
+  'sun-moon': SunMoon,
 } as const satisfies Record<string, LucideIconData>;
 
 export declare type ZardIcon = keyof typeof ZARD_ICONS | LucideIconData;

--- a/libs/zard/src/lib/components/layout/demo/sidebar.ts
+++ b/libs/zard/src/lib/components/layout/demo/sidebar.ts
@@ -32,7 +32,7 @@ interface MenuItem {
   ],
   standalone: true,
   template: `
-    <! -- border and rounded-md are just for the demo purpose - ->
+    <!-- border and rounded-md are just for the demo purpose -->
     <z-layout class="overflow-hidden rounded-md border">
       <z-sidebar
         [zWidth]="250"
@@ -40,7 +40,7 @@ interface MenuItem {
         [zCollapsed]="sidebarCollapsed()"
         [zCollapsedWidth]="70"
         (zCollapsedChange)="onCollapsedChange($event)"
-        class="!p-0"
+        class="p-0!"
       >
         <nav [class]="'flex h-full flex-col overflow-hidden ' + (sidebarCollapsed() ? 'gap-1 p-1 pt-4' : 'gap-4 p-4')">
           <z-sidebar-group>
@@ -49,6 +49,7 @@ interface MenuItem {
             }
             @for (item of mainMenuItems; track item.label) {
               <button
+                type="button"
                 z-button
                 zType="ghost"
                 [class]="sidebarCollapsed() ? 'justify-center' : 'justify-start'"
@@ -70,6 +71,7 @@ interface MenuItem {
             @for (item of workspaceMenuItems; track item.label) {
               @if (item.submenu) {
                 <button
+                  type="button"
                   z-button
                   zType="ghost"
                   z-menu
@@ -89,12 +91,13 @@ interface MenuItem {
                 <ng-template #submenu>
                   <div z-menu-content class="w-48">
                     @for (subitem of item.submenu; track subitem.label) {
-                      <button z-menu-item>{{ subitem.label }}</button>
+                      <button type="button" z-menu-item>{{ subitem.label }}</button>
                     }
                   </div>
                 </ng-template>
               } @else {
                 <button
+                  type="button"
                   z-button
                   zType="ghost"
                   [class]="sidebarCollapsed() ? 'justify-center' : 'justify-start'"
@@ -134,16 +137,16 @@ interface MenuItem {
 
             <ng-template #userMenu>
               <div z-menu-content class="w-48">
-                <button z-menu-item>
+                <button type="button" z-menu-item>
                   <z-icon zType="user" class="mr-2" />
                   Profile
                 </button>
-                <button z-menu-item>
+                <button type="button" z-menu-item>
                   <z-icon zType="settings" class="mr-2" />
                   Settings
                 </button>
                 <z-divider zSpacing="sm" />
-                <button z-menu-item>
+                <button type="button" z-menu-item>
                   <z-icon zType="log-out" class="mr-2" />
                   Logout
                 </button>
@@ -153,10 +156,10 @@ interface MenuItem {
         </nav>
       </z-sidebar>
 
-      <! -- min-h-[200px] is just for the demo purpose to have a minimum height - ->
+      <!-- min-h-[200px] is just for the demo purpose to have a minimum height -->
       <z-content class="min-h-[200px]">
         <div class="flex items-center">
-          <button z-button zType="ghost" zSize="sm" class="-ml-2" (click)="toggleSidebar()">
+          <button type="button" z-button zType="ghost" zSize="sm" class="-ml-2" (click)="toggleSidebar()">
             <z-icon zType="panel-left" />
           </button>
 


### PR DESCRIPTION
## What was done? 📝

Prevented theme flickering on startup. Added system mode to dark mode service and to the main Zard site. Now site user can choose what mode they prefer: system (depends on OS settings), always light or always dark.

## Screenshots or GIFs 📸

<img width="231" height="77" alt="image" src="https://github.com/user-attachments/assets/ddfd203d-07b6-4b8f-8e59-63ae4a0fdc07" />

## Link to Issue 🔗

#336 

## Type of change 🏗

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Refactor (non-breaking change that improves the code or technical debt)
- [ ] Chore (none of the above, such as upgrading libraries)

## Breaking change 🚨

Old way should work

## Checklist 🧐

- [x] Tested on Chrome
- [ ] Tested on Safari
- [ ] Tested on Firefox
- [x] No errors in the console


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full support for SYSTEM, LIGHT, and DARK theme modes with persistent selection.
  * Three-button theme control (System / Light / Dark) and new sun-moon icon.

* **Improvements**
  * Automatic system-theme detection and initialization on page load.
  * Documentation page styling and layout refreshed; change detection optimized.

* **Bug Fixes / Accessibility**
  * Prevented unintended form submissions by adding button types; improved interactive control ARIA states.

* **Style**
  * Fixed utility CSS important-modifier syntax.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->