### PR TITLE
🐛 fix: taking correct element for width calculation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,33 @@
+name: CI/Unit Tests
+
+on:
+  push:
+    branches: ['main', 'master']
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: ['main', 'master']
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  build-and-test:
+    # Specifies the runner environment for the job
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Step 4: Runs the unit tests
+      - name: Run unit tests
+        run: npm test

--- a/apps/web/public/installation/manual/select.md
+++ b/apps/web/public/installation/manual/select.md
@@ -6,6 +6,7 @@ import { TemplatePortal } from '@angular/cdk/portal';
 import { CommonModule, isPlatformBrowser } from '@angular/common';
 import {
   type AfterContentInit,
+  afterNextRender,
   ChangeDetectionStrategy,
   Component,
   computed,
@@ -14,11 +15,13 @@ import {
   ElementRef,
   forwardRef,
   inject,
+  Injector,
   input,
   model,
   type OnDestroy,
   output,
   PLATFORM_ID,
+  runInInjectionContext,
   signal,
   type TemplateRef,
   viewChild,
@@ -37,7 +40,7 @@ import {
   selectVariants,
   type ZardSelectSizeVariants,
 } from './select.variants';
-import { isElementContentTruncated, mergeClasses, transform } from '../../shared/utils/utils';
+import { mergeClasses, transform } from '../../shared/utils/utils';
 import { ZardBadgeComponent } from '../badge/badge.component';
 import { ZardIconComponent } from '../icon/icon.component';
 
@@ -111,6 +114,7 @@ type OnChangeType = (value: string) => void;
 export class ZardSelectComponent implements ControlValueAccessor, AfterContentInit, OnDestroy {
   private readonly destroyRef = inject(DestroyRef);
   private readonly elementRef = inject(ElementRef);
+  private readonly injector = inject(Injector);
   private readonly overlay = inject(Overlay);
   private readonly overlayPositionBuilder = inject(OverlayPositionBuilder);
   private readonly viewContainerRef = inject(ViewContainerRef);
@@ -330,13 +334,12 @@ export class ZardSelectComponent implements ControlValueAccessor, AfterContentIn
     this.overlayRef.updateSize({ width: hostWidth });
     this.isOpen.set(true);
 
-    this.determinePortalWidth(hostWidth);
+    this.determinePortalWidthOnOpen(hostWidth);
+  }
 
-    // Focus dropdown after opening and position on selected item
-    setTimeout(() => {
-      this.focusDropdown();
-      this.focusSelectedItem();
-    }, 0);
+  private setFocusOnOpen(): void {
+    this.focusDropdown();
+    this.focusSelectedItem();
   }
 
   private close() {
@@ -352,30 +355,43 @@ export class ZardSelectComponent implements ControlValueAccessor, AfterContentIn
     return this.selectItems()?.find(item => item.zValue() === value);
   }
 
-  private determinePortalWidth(portalWidth: number): void {
-    if (!this.overlayRef?.hasAttached()) {
-      return;
-    }
+  private determinePortalWidthOnOpen(portalWidth: number): void {
+    runInInjectionContext(this.injector, () => {
+      afterNextRender(() => {
+        if (!this.overlayRef || !this.overlayRef.hasAttached()) {
+          return;
+        }
 
-    const selectItems = this.selectItems();
-    let itemMaxWidth = 0;
-    for (const item of selectItems) {
-      itemMaxWidth = Math.max(itemMaxWidth, item.elementRef.nativeElement.scrollWidth);
-    }
+        const selectItems = this.selectItems();
+        let itemMaxWidth = 0;
+        for (const item of selectItems) {
+          itemMaxWidth = Math.max(itemMaxWidth, item.elementRef.nativeElement.scrollWidth);
+        }
 
-    const textContentElement = this.elementRef.nativeElement.querySelector('button > span > span') as HTMLElement;
-    const isOverflow = isElementContentTruncated(textContentElement);
+        const overlayPaneElement = this.overlayRef.overlayElement;
+        const textElements = Array.from(overlayPaneElement.querySelectorAll<HTMLElement>('z-select-item > span'));
+        let isOverflow = false;
+        for (const textElement of textElements) {
+          if (textElement.scrollWidth > textElement.clientWidth) {
+            isOverflow = true;
+            break;
+          }
+        }
 
-    if (isOverflow && selectItems.length) {
-      const elementStyles = getComputedStyle(selectItems[0].elementRef.nativeElement);
-      const leftPadding = Number.parseFloat(elementStyles.getPropertyValue('padding-left')) || 0;
-      const rightPadding = Number.parseFloat(elementStyles.getPropertyValue('padding-right')) || 0;
-      itemMaxWidth += leftPadding + rightPadding;
-    }
+        if (isOverflow && selectItems.length) {
+          const elementStyles = getComputedStyle(selectItems[0].elementRef.nativeElement);
+          const leftPadding = Number.parseFloat(elementStyles.getPropertyValue('padding-left')) || 0;
+          const rightPadding = Number.parseFloat(elementStyles.getPropertyValue('padding-right')) || 0;
+          itemMaxWidth += leftPadding + rightPadding;
+        }
 
-    itemMaxWidth = Math.max(itemMaxWidth, portalWidth);
-    this.overlayRef.updateSize({ width: itemMaxWidth });
-    this.overlayRef.updatePosition();
+        itemMaxWidth = Math.max(itemMaxWidth, portalWidth);
+        this.overlayRef.updateSize({ width: itemMaxWidth });
+        this.overlayRef.updatePosition();
+
+        this.setFocusOnOpen();
+      });
+    });
   }
 
   private createOverlay() {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -335,3 +335,18 @@ table.api-table--pipe tbody td:first-child code {
     flex: 0 0 calc(344px / 1.2);
   }
 }
+
+::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+
+::-webkit-scrollbar-thumb {
+  background: var(--muted-foreground);
+  border-radius: 5px;
+}
+
+::-webkit-scrollbar-track {
+  border-radius: 5px;
+  background: var(--muted);
+}

--- a/libs/zard/src/lib/components/select/select.component.spec.ts
+++ b/libs/zard/src/lib/components/select/select.component.spec.ts
@@ -1,5 +1,5 @@
 import { Component, signal } from '@angular/core';
-import { type ComponentFixture, TestBed } from '@angular/core/testing';
+import { type ComponentFixture, fakeAsync, flush, TestBed } from '@angular/core/testing';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 
@@ -69,25 +69,29 @@ describe('ZardSelectComponent', () => {
     });
 
     describe('keyboard navigation', () => {
-      it('should open dropdown on Enter key', () => {
+      it('should open dropdown on Enter key', fakeAsync(() => {
         const event = new KeyboardEvent('keydown', { key: 'Enter' });
         jest.spyOn(event, 'preventDefault');
 
         component.onTriggerKeydown(event);
+        flush();
+        fixture.detectChanges();
 
         expect(event.preventDefault).toHaveBeenCalled();
         expect(component.isOpen()).toBeTruthy();
-      });
+      }));
 
-      it('should open dropdown on Space key', () => {
+      it('should open dropdown on Space key', fakeAsync(() => {
         const event = new KeyboardEvent('keydown', { key: ' ' });
         jest.spyOn(event, 'preventDefault');
 
         component.onTriggerKeydown(event);
+        flush();
+        fixture.detectChanges();
 
         expect(event.preventDefault).toHaveBeenCalled();
         expect(component.isOpen()).toBeTruthy();
-      });
+      }));
 
       it('should close dropdown on Escape key', () => {
         component.toggle();
@@ -234,15 +238,16 @@ describe('ZardSelectComponent', () => {
       expect(onChangeSpy).toHaveBeenCalledWith('apple');
     });
 
-    it('should call onTouched when dropdown closes', () => {
+    it('should call onTouched when dropdown closes', fakeAsync(() => {
       const onTouchedSpy = jest.fn();
       selectComponent.registerOnTouched(onTouchedSpy);
 
       selectComponent.toggle(); // open
+      flush();
       selectComponent.toggle(); // close
 
       expect(onTouchedSpy).toHaveBeenCalled();
-    });
+    }));
   });
 
   describe('signal reactivity', () => {

--- a/libs/zard/src/lib/shared/utils/utils.ts
+++ b/libs/zard/src/lib/shared/utils/utils.ts
@@ -15,15 +15,3 @@ export function generateId(prefix = ''): string {
 }
 
 export const noopFun = () => void 0;
-
-export const isElementContentTruncated = (element: HTMLElement | undefined): boolean => {
-  if (!element) {
-    return false;
-  }
-  const range = document.createRange();
-  range.selectNodeContents(element);
-  const rangeWidth = range.getBoundingClientRect().width;
-  const elementWidth = element.getBoundingClientRect().width;
-
-  return rangeWidth > elementWidth;
-};


### PR DESCRIPTION
## What was done? 📝

Fixed the way we calculate width of dropdown content on fly. 

## Screenshots or GIFs 📸

|-----Figma-----|
|-----Implementation-----|

## Link to Issue 🔗

#342 

## Type of change 🏗

- [ ] New feature (non-breaking change that adds functionality)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Refactor (non-breaking change that improves the code or technical debt)
- [ ] Chore (none of the above, such as upgrading libraries)

## Breaking change 🚨

no breaking changes

## Checklist 🧐

- [x] Tested on Chrome
- [ ] Tested on Safari
- [x] Tested on Firefox
- [x] No errors in the console


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Added custom scrollbar styling for WebKit browsers for improved visual consistency.

* **Bug Fixes**
  * Improved select overlay sizing, positioning and post-open focus timing for more reliable interaction and readability.
  * Updated overflow detection for clearer item truncation handling.

* **Tests**
  * Strengthened select keyboard tests by synchronizing async timers and change detection.

* **Chores**
  * Removed an unused utility export (affects internal helpers).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->