### PR TITLE
🐛 fix: light or dark colors for code  properly follow dark mode servi…

### DIFF
--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -54,9 +54,6 @@
   --code-tab-button: oklch(0.925 0 0);
   --selection: oklch(0.145 0 0);
   --selection-foreground: oklch(1 0 0);
-  --shiki--light: github-light;
-  --shiki--dark: github-dark;
-  --shiki-theme: var(--shiki--light);
 }
 
 .dark {
@@ -100,7 +97,6 @@
   --code-tab-button: oklch(0.178 0 0);
   --selection: oklch(0.922 0 0);
   --selection-foreground: oklch(0.205 0 0);
-  --shiki-theme: var(--shiki--dark);
 }
 
 @theme inline {
@@ -262,13 +258,13 @@ code[data-line-numbers-max-digits='4'] > [data-line]::before {
   width: 2.25rem;
 }
 
-code[data-theme*=' '],
-code[data-theme*=' '] span {
+code,
+code span {
   color: var(--shiki-light);
 }
 
-[data-theme='dark'] code[data-theme*=' '],
-[data-theme='dark'] code[data-theme*=' '] span {
+.dark code,
+.dark code span {
   color: var(--shiki-dark);
 }
 


### PR DESCRIPTION
## What was done? 📝

Fix: Dark mode syntax highlighting for code blocks
Problem
Code syntax highlighting was not working correctly in dark mode due to CSS selectors relying on [data-theme='dark'] attribute instead of the .dark class that the ZardDarkMode service actually manages.

Changes
Updated CSS selectors to use .dark class instead of [data-theme='dark'] attribute

Fixed CSS variable naming: --shiki--light → --shiki-light (removed double dashes)

Technical Details
The ZardDarkMode service toggles the .dark class on the <html> element (line 77 in dark-mode.ts), but the syntax highlighting CSS was checking the data-theme attribute. This mismatch caused code blocks to not apply dark theme styles correctly.


## Screenshots or GIFs 📸

|-----Figma-----|
|-----Implementation-----|

## Link to Issue 🔗

closes #389 

## Type of change 🏗

- [ ] New feature (non-breaking change that adds functionality)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Refactor (non-breaking change that improves the code or technical debt)
- [ ] Chore (none of the above, such as upgrading libraries)

## Breaking change 🚨

<!-- describe here the breaking changes -->

## Checklist 🧐

- [x] Tested on Chrome
- [ ] Tested on Safari
- [ ] Tested on Firefox
- [x] No errors in the console


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Simplified theme handling for code blocks by removing redundant root-level theme wiring.
  * Switched dark-mode theming to a class-based approach for more predictable styling.
  * Broadened color application to code elements for more consistent syntax highlighting across light and dark modes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->