### PR TITLE
🚧 chore(libs): peer dependency update

### DIFF
--- a/libs/zard/package-lock.json
+++ b/libs/zard/package-lock.json
@@ -8,6 +8,7 @@
       "name": "@ngzard/ui",
       "version": "1.0.0-beta.31",
       "peerDependencies": {
+        "@angular/aria": "^21.0.0",
         "@angular/cdk": "^21.0.0",
         "@angular/common": "^21.0.0",
         "@angular/core": "^21.0.0",
@@ -25,6 +26,19 @@
         "ngx-sonner": "^3.1.0",
         "rxjs": "^7.8.2",
         "tailwind-merge": "^3.4.0"
+      }
+    },
+    "node_modules/@angular/aria": {
+      "version": "21.0.6",
+      "resolved": "https://registry.npmjs.org/@angular/aria/-/aria-21.0.6.tgz",
+      "integrity": "sha512-yEo0wOK7g9wu4/7kWxHqwNKI2AdwDHDzTNnios8G8TA6oOyhFEbzcUC4ma5egD5WMeR79Ha+ScVSeDDdq+jF3A==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/cdk": "21.0.6",
+        "@angular/core": "^21.0.0 || ^22.0.0"
       }
     },
     "node_modules/@angular/cdk": {
@@ -322,8 +336,7 @@
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "peer": true
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/wheel-gestures": {
       "version": "2.2.48",

--- a/libs/zard/package.json
+++ b/libs/zard/package.json
@@ -2,26 +2,29 @@
   "name": "@ngzard/ui",
   "version": "1.0.0-beta.31",
   "peerDependencies": {
+    "@angular/cdk": "^21.0.0",
+    "@angular/common": "^21.0.0",
     "@angular/core": "^21.0.0",
+    "@angular/forms": "^21.0.0",
+    "@angular/platform-browser": "^21.0.0",
+    "@angular/router": "^21.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "tailwind-merge": "^3.4.0",
-    "@angular/forms": "^21.0.0",
-    "@angular/common": "^21.0.0",
-    "@angular/router": "^21.0.0",
-    "rxjs": "^7.8.2",
-    "@angular/cdk": "^21.0.0",
-    "ngx-sonner": "^3.1.0",
+    "embla-carousel": "^8.6.0",
+    "embla-carousel-angular": "^21.0.0",
     "embla-carousel-autoplay": "^8.6.0",
     "embla-carousel-class-names": "^8.6.0",
     "embla-carousel-wheel-gestures": "^8.1.0",
-    "embla-carousel": "^8.6.0",
-    "embla-carousel-angular": "^21.0.0",
     "lucide-angular": "^0.562.0",
-    "@angular/platform-browser": "^21.0.0"
+    "ngx-sonner": "^3.1.0",
+    "rxjs": "^7.8.2",
+    "tailwind-merge": "^3.4.0"
   },
   "sideEffects": false,
   "publishConfig": {
     "access": "public"
+  },
+  "dependencies": {
+    "@angular/aria": "^21.0.6"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0-beta.31",
       "license": "MIT",
       "dependencies": {
+        "@angular/aria": "^21.0.6",
         "@angular/cdk": "21.0.6",
         "@angular/common": "21.0.8",
         "@angular/compiler": "21.0.8",
@@ -780,6 +781,19 @@
         "@typescript-eslint/utils": "^7.11.0 || ^8.0.0",
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": "*"
+      }
+    },
+    "node_modules/@angular/aria": {
+      "version": "21.0.6",
+      "resolved": "https://registry.npmjs.org/@angular/aria/-/aria-21.0.6.tgz",
+      "integrity": "sha512-yEo0wOK7g9wu4/7kWxHqwNKI2AdwDHDzTNnios8G8TA6oOyhFEbzcUC4ma5egD5WMeR79Ha+ScVSeDDdq+jF3A==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/cdk": "21.0.6",
+        "@angular/core": "^21.0.0 || ^22.0.0"
       }
     },
     "node_modules/@angular/build": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "node": "22 || 20"
   },
   "dependencies": {
+    "@angular/aria": "^21.0.6",
     "@angular/cdk": "21.0.6",
     "@angular/common": "21.0.8",
     "@angular/compiler": "21.0.8",


### PR DESCRIPTION
## What was done? 📝

Zard libs package.json peer dependency update

## Screenshots or GIFs 📸

|-----Figma-----|
|-----Implementation-----|

## Link to Issue 🔗

<!-- provide the link to the related issue here -->

## Type of change 🏗

- [ ] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Refactor (non-breaking change that improves the code or technical debt)
- [x] Chore (none of the above, such as upgrading libraries)

## Breaking change 🚨

<!-- describe here the breaking changes -->

## Checklist 🧐

- [ ] Tested on Chrome
- [ ] Tested on Safari
- [ ] Tested on Firefox
- [ ] No errors in the console


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Angular peer dependencies from 20.x to 21.x and added platform-browser.
  * Moved rxjs from peerDependencies to dependencies.
  * Added @angular/aria as a runtime dependency.
  * Added embla-carousel and embla-carousel-angular peer dependencies.
  * Removed ngx-sonner from peerDependencies.
  * Bumped tailwind-merge to ^3.4.0 and updated lucide-angular to ^0.562.0.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->