### PR TITLE
Update select.component.ts

### DIFF
--- a/libs/zard/src/lib/shared/components/select/select.component.ts
+++ b/libs/zard/src/lib/shared/components/select/select.component.ts
@@ -63,7 +63,7 @@ const COMPACT_MODE_WIDTH_THRESHOLD = 100;
       (click)="toggle()"
       (focus)="onFocus()"
     >
-      <span class="flex flex-1 flex-wrap items-center gap-2">
+      <span class="flex flex-1 flex-wrap items-center gap-2 min-w-0">
         @for (label of selectedLabels(); track label) {
           @if (zMultiple()) {
             <z-badge zType="secondary">


### PR DESCRIPTION
**Fix flex item overflow by adding `min-width: 0`**

## What was done? 📝

Fixed a layout issue where flex items containing text elements would not shrink below their intrinsic content width, causing overflow in constrained containers.
  Added `min-width: 0` to the flex child element, allowing it to shrink properly and prevent unwanted horizontal scrolling or content clipping.

## Screenshots or GIFs 📸

| Before | After |
|--------|-------|
| <img width="494" height="231" alt="Before fix" src="https://github.com/user-attachments/assets/efedb392-935f-4090-a51b-d61a359e849f" /> | <img width="414" height="204" alt="After fix" src="https://github.com/user-attachments/assets/49462b77-e593-4d89-a743-489536af2476" /> |

## Link to Issue 🔗

<!-- provide the link to the related issue here -->

## Type of change 🏗

- [ ] New feature (non-breaking change that adds functionality)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Refactor (non-breaking change that improves the code or technical debt)
- [ ] Chore (none of the above, such as upgrading libraries)

## Breaking change 🚨

No breaking changes — this is a CSS-only fix that only affects visual layout behavior in flex containers.

## Checklist 🧐

- [x] Tested on Chrome
- [x] Tested on Safari
- [ ] Tested on Firefox
- [x] No errors in the console

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved select component layout behavior to better handle content truncation and overflow when displaying selected values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->