### PR TITLE
Fix popover click event

### DIFF
--- a/libs/zard/src/lib/shared/components/popover/popover.component.ts
+++ b/libs/zard/src/lib/shared/components/popover/popover.component.ts
@@ -205,7 +205,7 @@ export class ZardPopoverDirective implements OnInit, OnDestroy {
     }
 
     if (trigger === 'click') {
-      this.listeners.push(this.renderer.listen(this.nativeElement, 'click.stop', () => this.toggle()));
+      this.listeners.push(this.renderer.listen(this.nativeElement, 'click', () => this.toggle()));
     } else if (trigger === 'hover') {
       this.listeners.push(this.renderer.listen(this.nativeElement, 'mouseenter', () => this.show()));
 


### PR DESCRIPTION
## What was done? 📝
in the popover component, and any component related to it, like date picker
changing event name in this : 
```
private setupTriggers() {
    const trigger = this.zTrigger();
    if (!trigger) {
      return;
    }

    if (trigger === 'click') {
      this.listeners.push(this.renderer.listen(this.nativeElement, 'click', () => this.toggle()));
    } else if (trigger === 'hover') {
      this.listeners.push(this.renderer.listen(this.nativeElement, 'mouseenter', () => this.show()));

      this.listeners.push(this.renderer.listen(this.nativeElement, 'mouseleave', () => this.hide()));
    }
  }
```
from click.stop to just click

## Screenshots or GIFs 📸

|-----Figma-----|
|-----Implementation-----|

## Link to Issue 🔗

(https://github.com/zard-ui/zardui/issues/429)

## Type of change 🏗

change in code, the code need to be reviewed 

## Breaking change 🚨

<!-- describe here the breaking changes -->

## Checklist 🧐

- [x ] Tested on Chrome
- [ ] Tested on Safari
- [ x] Tested on Firefox
- [ x] No errors in the console


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Popover component now allows click events to propagate normally, enabling proper interaction with elements behind the popover.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->