### PR TITLE
🐛 fix(dark-mode): add ngSkipHydration to dark mode page component

### DIFF
--- a/apps/web/public/r/registry.json
+++ b/apps/web/public/r/registry.json
@@ -2,7 +2,7 @@
   "$schema": "https://zardui.com/schema/registry.json",
   "name": "@ngzard",
   "homepage": "https://zardui.com",
-  "version": "1.0.0-beta.45",
+  "version": "1.0.0-beta.46",
   "items": [
     {
       "name": "core",

--- a/apps/web/src/app/domain/pages/dark-mode/dark-mode.page.ts
+++ b/apps/web/src/app/domain/pages/dark-mode/dark-mode.page.ts
@@ -17,6 +17,7 @@ import { ScrollSpyDirective } from '../../directives/scroll-spy.directive';
 
 @Component({
   selector: 'z-darkmode',
+  host: { ngSkipHydration: '' },
   imports: [
     DocContentComponent,
     DocHeadingComponent,


### PR DESCRIPTION
## What was done? 📝

I noticed that system button is sometimes clickable but sometimes it is not, even direct light or dark mode is enabled, which means user cannot switch back to system mode. The problem happens because of hydration mismatch and fastest way to solve the problem is to force CSR mode for this page by skipping hydration directive. 

## Screenshots or GIFs 📸

|-----Figma-----|
|-----Implementation-----|

## Link to Issue 🔗

<!-- provide the link to the related issue here -->

## Type of change 🏗

- [ ] New feature (non-breaking change that adds functionality)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Refactor (non-breaking change that improves the code or technical debt)
- [ ] Chore (none of the above, such as upgrading libraries)

## Breaking change 🚨

<!-- describe here the breaking changes -->

## Checklist 🧐

- [x] Tested on Chrome
- [ ] Tested on Safari
- [ ] Tested on Firefox
- [x] No errors in the console


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized the dark mode page's hydration handling to improve application performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->