### PR TITLE
✨ feat(generators): add Nx component scaffold generator

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "publish:cli": "npx nx run cli:publish",
     "release": "npx nx release",
     "release:dry-run": "npx nx release --dry-run",
-    "serve:ssr": "node dist/apps/web/server/server.mjs"
+    "serve:ssr": "node dist/apps/web/server/server.mjs",
+    "generate:component": "nx generate @zardui/generators:component"
   },
   "engines": {
     "node": ">=20.19.0"

--- a/tools/generators.json
+++ b/tools/generators.json
@@ -1,0 +1,9 @@
+{
+  "generators": {
+    "component": {
+      "factory": "./generators/component",
+      "schema": "./generators/component/schema.json",
+      "description": "Generate a new Zard UI component"
+    }
+  }
+}

--- a/tools/generators/component/files/__name__/__name__.component.spec.ts.template
+++ b/tools/generators/component/files/__name__/__name__.component.spec.ts.template
@@ -1,0 +1,22 @@
+import { type ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { Zard<%= className %>Component } from './<%= name %>.component';
+
+describe('<%= className %>Component', () => {
+  let component: Zard<%= className %>Component;
+  let fixture: ComponentFixture<Zard<%= className %>Component>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [Zard<%= className %>Component],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(Zard<%= className %>Component);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/tools/generators/component/files/__name__/__name__.component.ts.template
+++ b/tools/generators/component/files/__name__/__name__.component.ts.template
@@ -1,0 +1,27 @@
+import { ChangeDetectionStrategy, Component, computed, input, ViewEncapsulation } from '@angular/core';
+
+import type { ClassValue } from 'clsx';
+
+import { mergeClasses } from '@/shared/utils/merge-classes';
+
+import { <%= variantName %>Variants } from './<%= name %>.variants';
+
+@Component({
+  selector: '<%= selector %>',
+  template: `
+    <ng-content />
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  host: {
+    '[class]': 'classes()',
+  },
+  exportAs: '<%= exportAs %>',
+})
+export class Zard<%= className %>Component {
+  readonly class = input<ClassValue>('');
+
+  protected readonly classes = computed(() =>
+    mergeClasses(<%= variantName %>Variants(), this.class()),
+  );
+}

--- a/tools/generators/component/files/__name__/__name__.variants.ts.template
+++ b/tools/generators/component/files/__name__/__name__.variants.ts.template
@@ -1,0 +1,4 @@
+import { cva, type VariantProps } from 'class-variance-authority';
+
+export const <%= variantName %>Variants = cva('');
+export type Zard<%= className %>Variants = VariantProps<typeof <%= variantName %>Variants>;

--- a/tools/generators/component/files/__name__/demo/__name__.ts.template
+++ b/tools/generators/component/files/__name__/demo/__name__.ts.template
@@ -1,0 +1,13 @@
+import { ZardDemo<%= className %>DefaultComponent } from './default';
+
+export const <%= constantName %> = {
+  componentName: '<%= name %>',
+  componentType: '<%= name %>',
+  description: '<%= description %>',
+  examples: [
+    {
+      name: 'default',
+      component: ZardDemo<%= className %>DefaultComponent,
+    },
+  ],
+};

--- a/tools/generators/component/files/__name__/demo/default.ts.template
+++ b/tools/generators/component/files/__name__/demo/default.ts.template
@@ -1,0 +1,13 @@
+import { Component } from '@angular/core';
+
+import { Zard<%= className %>Component } from '../<%= name %>.component';
+
+@Component({
+  selector: 'z-demo-<%= name %>-default',
+  standalone: true,
+  imports: [Zard<%= className %>Component],
+  template: `
+    <<%= selector %>><%= className %></<%= selector %>>
+  `,
+})
+export class ZardDemo<%= className %>DefaultComponent {}

--- a/tools/generators/component/files/__name__/doc/api.md.template
+++ b/tools/generators/component/files/__name__/doc/api.md.template
@@ -1,0 +1,9 @@
+# API Reference
+
+[<%= selector %>] Component
+
+<%= selector %> is a component that <%= descriptionLower %>
+
+| Property  | Description        | Type     | Default |
+| --------- | ------------------ | -------- | ------- |
+| `[class]` | Custom CSS classes | `string` | `''`    |

--- a/tools/generators/component/files/__name__/index.ts.template
+++ b/tools/generators/component/files/__name__/index.ts.template
@@ -1,0 +1,2 @@
+export * from './<%= name %>.component';
+export * from './<%= name %>.variants';

--- a/tools/generators/component/index.ts
+++ b/tools/generators/component/index.ts
@@ -1,0 +1,146 @@
+import { type Tree, formatFiles, generateFiles } from '@nx/devkit';
+import * as path from 'path';
+
+import type { ComponentGeneratorSchema } from './schema';
+
+const COMPONENTS_DIR = 'libs/zard/src/lib/shared/components';
+const PUBLIC_COMPONENTS_DIR = 'apps/web/public/components';
+const INDEX_PATH = 'libs/zard/src/index.ts';
+const REGISTRY_PATH = 'apps/web/src/app/shared/constants/components.constant.ts';
+const ROUTES_PATH = 'apps/web/src/app/shared/constants/routes.constant.ts';
+
+function toClassName(name: string): string {
+  return name
+    .split('-')
+    .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+    .join('');
+}
+
+function toConstantName(name: string): string {
+  return name.replace(/-/g, '_').toUpperCase();
+}
+
+function toCamelCase(name: string): string {
+  const pascal = toClassName(name);
+  return pascal.charAt(0).toLowerCase() + pascal.slice(1);
+}
+
+function toDisplayName(name: string): string {
+  return name
+    .split('-')
+    .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+export default async function componentGenerator(tree: Tree, schema: ComponentGeneratorSchema) {
+  const kebabName = schema.name.toLowerCase();
+  const className = toClassName(kebabName);
+  const constantName = toConstantName(kebabName);
+  const exportAs = 'z' + className;
+  const selector = `z-${kebabName}`;
+  const displayName = toDisplayName(kebabName);
+
+  const variantName = toCamelCase(kebabName);
+
+  const desc = schema.description;
+  const descriptionLower = desc.charAt(0).toLowerCase() + desc.slice(1);
+
+  const templateVars = {
+    name: kebabName,
+    variantName,
+    className,
+    constantName,
+    selector,
+    exportAs,
+    description: desc,
+    descriptionLower,
+    template: '',
+  };
+
+  // 1. Generate component files from templates
+  generateFiles(tree, path.join(__dirname, 'files'), COMPONENTS_DIR, templateVars);
+
+  // 2. Generate public markdown files (demo code tab + docs)
+  generateFiles(tree, path.join(__dirname, 'public-files'), PUBLIC_COMPONENTS_DIR, templateVars);
+
+  // 3. Add export to libs/zard/src/index.ts
+  addExportToIndex(tree, kebabName);
+
+  // 4. Add entry to COMPONENTS_REGISTRY
+  addRegistryEntry(tree, kebabName, constantName, desc);
+
+  // 5. Add entry to COMPONENTS_PATH routes
+  addRouteEntry(tree, kebabName, displayName);
+
+  await formatFiles(tree);
+}
+
+function addExportToIndex(tree: Tree, name: string): void {
+  const content = tree.read(INDEX_PATH, 'utf-8');
+  if (!content) return;
+
+  const newExport = `export * from './lib/shared/components/${name}';`;
+
+  if (content.includes(newExport)) return;
+
+  // Find all component exports and insert alphabetically
+  const lines = content.split('\n');
+  const componentExports = lines.filter(line => line.includes("'./lib/shared/components/"));
+  const otherLines = lines.filter(line => !line.includes("'./lib/shared/components/"));
+
+  componentExports.push(newExport);
+  componentExports.sort((a, b) => a.localeCompare(b));
+
+  // Reconstruct: non-component lines first, then sorted component exports
+  const nonEmptyOther = otherLines.filter(line => line.trim() !== '');
+  const result = [...nonEmptyOther, ...componentExports, ''].join('\n');
+
+  tree.write(INDEX_PATH, result);
+}
+
+function addRegistryEntry(tree: Tree, name: string, constantName: string, description: string): void {
+  const content = tree.read(REGISTRY_PATH, 'utf-8');
+  if (!content) return;
+
+  // Check if entry already exists
+  if (content.includes(`componentName: '${name}'`)) return;
+
+  const entry = `  {
+    componentName: '${name}',
+    description: '${description.replace(/'/g, "\\'")}',
+    loadData: () => import('@zard/components/${name}/demo/${name}').then(m => m.${constantName}),
+  },`;
+
+  // Insert before the closing bracket of the array
+  const closingIndex = content.lastIndexOf('];');
+  if (closingIndex === -1) return;
+
+  const before = content.slice(0, closingIndex);
+  const after = content.slice(closingIndex);
+
+  tree.write(REGISTRY_PATH, before + entry + '\n' + after);
+}
+
+function addRouteEntry(tree: Tree, name: string, displayName: string): void {
+  const content = tree.read(ROUTES_PATH, 'utf-8');
+  if (!content) return;
+
+  // Check if entry already exists
+  if (content.includes(`path: '/docs/components/${name}'`)) return;
+
+  const entry = `    { name: '${displayName}', path: '/docs/components/${name}', available: true },`;
+
+  // Find the .sort() line in COMPONENTS_PATH and insert before the closing bracket
+  // The array ends with `].sort((a, b) => a.name.localeCompare(b.name)),`
+  const sortPattern = /\]\.sort\(\(a, b\) => a\.name\.localeCompare\(b\.name\)\)/;
+  const match = content.match(sortPattern);
+
+  if (!match || match.index === undefined) return;
+
+  // Find the position just before the `]` that precedes `.sort(`
+  const insertPos = match.index;
+  const before = content.slice(0, insertPos);
+  const after = content.slice(insertPos);
+
+  tree.write(ROUTES_PATH, before + entry + '\n  ' + after);
+}

--- a/tools/generators/component/public-files/__name__/demo/default.md.template
+++ b/tools/generators/component/public-files/__name__/demo/default.md.template
@@ -1,0 +1,16 @@
+```angular-ts showLineNumbers copyButton
+import { Component } from '@angular/core';
+
+import { Zard<%= className %>Component } from '../<%= name %>.component';
+
+@Component({
+  selector: 'z-demo-<%= name %>-default',
+  standalone: true,
+  imports: [Zard<%= className %>Component],
+  template: `
+    <<%= selector %>><%= className %></<%= selector %>>
+  `,
+})
+export class ZardDemo<%= className %>DefaultComponent {}
+
+```

--- a/tools/generators/component/public-files/__name__/doc/api.md.template
+++ b/tools/generators/component/public-files/__name__/doc/api.md.template
@@ -1,0 +1,9 @@
+# API Reference
+
+[<%= selector %>] Component
+
+<%= selector %> is a component that <%= descriptionLower %>
+
+| Property  | Description        | Type     | Default |
+| --------- | ------------------ | -------- | ------- |
+| `[class]` | Custom CSS classes | `string` | `''`    |

--- a/tools/generators/component/schema.d.ts
+++ b/tools/generators/component/schema.d.ts
@@ -1,0 +1,4 @@
+export interface ComponentGeneratorSchema {
+  name: string;
+  description: string;
+}

--- a/tools/generators/component/schema.json
+++ b/tools/generators/component/schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/schema",
+  "cli": "nx",
+  "id": "component",
+  "title": "Generate a new Zard UI component",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Component name in kebab-case (e.g., 'date-picker')",
+      "x-prompt": "What is the component name?"
+    },
+    "description": {
+      "type": "string",
+      "description": "Short description of the component",
+      "x-prompt": "What does this component do?"
+    }
+  },
+  "required": ["name", "description"]
+}

--- a/tools/package.json
+++ b/tools/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@zardui/generators",
+  "version": "1.0.0",
+  "private": true,
+  "generators": "./generators.json"
+}

--- a/tools/project.json
+++ b/tools/project.json
@@ -1,0 +1,6 @@
+{
+  "name": "@zardui/generators",
+  "root": "tools",
+  "sourceRoot": "tools",
+  "projectType": "library"
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -13,7 +13,10 @@
     "skipLibCheck": true,
     "skipDefaultLibCheck": true,
     "baseUrl": ".",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "paths": {
+      "@zardui/generators": ["tools/generators/component/index.ts"]
+    }
   },
   "exclude": ["node_modules", "tmp"]
 }


### PR DESCRIPTION
## What was done? 📝

Add local Nx generator that automates Zard UI component creation. Generates lib files (component, variants, spec, demo, api.md) and public markdown files (demo code tab + api docs) with pre-filled content.

## Type of change 🏗

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Refactor (non-breaking change that improves the code or technical debt)
- [ ] Chore (none of the above, such as upgrading libraries)

## Checklist 🧐

- [ ] Tested on Chrome
- [ ] Tested on Safari
- [ ] Tested on Firefox
- [x] No errors in the console
