### PR TITLE
✨ feat(about): redesign founders and maintainers cards

### DIFF
--- a/apps/web/src/app/domain/components/founders/founders.component.ts
+++ b/apps/web/src/app/domain/components/founders/founders.component.ts
@@ -18,45 +18,31 @@ export interface FounderData {
   standalone: true,
   imports: [ZardAvatarComponent],
   template: `
-    <div class="flex flex-col gap-6 sm:gap-8">
+    <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
       @for (founder of founders(); track founder.login) {
         <a
           [href]="founder.html_url"
           target="_blank"
           rel="noopener noreferrer"
-          class="group from-card to-card/50 text-card-foreground relative block cursor-pointer overflow-hidden rounded-xl border bg-gradient-to-br p-8 no-underline shadow-lg transition-all duration-300 hover:scale-[1.01] hover:shadow-xl sm:p-10"
+          class="bg-card text-card-foreground group hover:bg-accent flex items-center gap-4 rounded-lg border p-4 no-underline transition-colors"
         >
-          <div
-            class="from-primary/5 absolute inset-0 bg-gradient-to-br to-transparent opacity-0 transition-opacity duration-300 group-hover:opacity-100"
-          ></div>
+          <z-avatar
+            [zSrc]="founder.avatar_url"
+            [zAlt]="founder.name + ' avatar'"
+            [zFallback]="founder.name.substring(0, 2).toUpperCase()"
+            zSize="lg"
+            class="shrink-0"
+          ></z-avatar>
 
-          <div class="relative flex flex-col items-start gap-6 sm:flex-row sm:items-center sm:gap-8">
-            <div class="relative shrink-0">
-              <div
-                class="from-primary/20 to-primary/5 absolute -inset-1 rounded-full bg-gradient-to-br opacity-0 blur-sm transition-opacity duration-300 group-hover:opacity-100"
-              ></div>
-              <z-avatar
-                [zSrc]="founder.avatar_url"
-                [zAlt]="founder.name + ' avatar'"
-                [zFallback]="founder.name.substring(0, 2).toUpperCase()"
-                zSize="xl"
-                class="ring-border group-hover:ring-primary/30 relative ring-2 transition-all"
-              ></z-avatar>
-            </div>
-
-            <div class="flex min-w-0 flex-1 flex-col gap-3 sm:gap-4">
-              <div class="flex flex-col gap-2">
-                <h3 class="text-2xl font-bold tracking-tight sm:text-3xl">{{ founder.name }}</h3>
-                <p class="text-primary text-base font-medium sm:text-lg">{{ founder.role }}</p>
-              </div>
-
-              <span
-                class="text-muted-foreground group-hover:text-primary inline-flex w-fit items-center gap-2 text-sm transition-colors sm:text-base"
-              >
-                <img [src]="githubData?.icon" [alt]="githubData?.iconAlt" class="h-4 sm:h-5 dark:invert" />
-                <span class="font-mono">@{{ founder.login }}</span>
-              </span>
-            </div>
+          <div class="flex min-w-0 flex-col gap-0.5">
+            <h3 class="truncate text-sm font-semibold">{{ founder.name }}</h3>
+            <p class="text-muted-foreground truncate text-xs">{{ founder.role }}</p>
+            <span
+              class="text-muted-foreground group-hover:text-foreground mt-1 inline-flex items-center gap-1.5 text-xs transition-colors"
+            >
+              <img [src]="githubData?.icon" [alt]="githubData?.iconAlt" class="h-3 dark:invert" />
+              <span class="truncate font-mono">{{ founder.login }}</span>
+            </span>
           </div>
         </a>
       }

--- a/apps/web/src/app/domain/components/maintainers/maintainers.component.ts
+++ b/apps/web/src/app/domain/components/maintainers/maintainers.component.ts
@@ -18,47 +18,30 @@ export interface MaintainerData {
   standalone: true,
   imports: [ZardAvatarComponent],
   template: `
-    <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 sm:gap-6">
+    <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
       @for (maintainer of maintainers(); track maintainer.login) {
         <a
           [href]="maintainer.html_url"
           target="_blank"
           rel="noopener noreferrer"
-          class="group from-card to-card/50 text-card-foreground relative block cursor-pointer overflow-hidden rounded-lg border bg-gradient-to-br p-4 no-underline shadow-sm transition-all duration-300 hover:scale-[1.02] hover:shadow-lg sm:p-6"
+          class="bg-card text-card-foreground group hover:bg-accent flex items-center gap-3 rounded-lg border p-3 no-underline transition-colors"
         >
-          <div
-            class="from-primary/5 absolute inset-0 bg-gradient-to-br to-transparent opacity-0 transition-opacity duration-300 group-hover:opacity-100"
-          ></div>
+          <z-avatar
+            [zSrc]="maintainer.avatar_url"
+            [zAlt]="maintainer.name + ' avatar'"
+            [zFallback]="maintainer.name.substring(0, 2).toUpperCase()"
+            zSize="md"
+            class="shrink-0"
+          ></z-avatar>
 
-          <div class="relative flex items-start gap-4">
-            <div class="relative shrink-0">
-              <div
-                class="from-primary/20 to-primary/5 absolute -inset-0.5 rounded-full bg-gradient-to-br opacity-0 blur-sm transition-opacity duration-300 group-hover:opacity-100"
-              ></div>
-              <z-avatar
-                [zSrc]="maintainer.avatar_url"
-                [zAlt]="maintainer.name + ' avatar'"
-                [zFallback]="maintainer.name.substring(0, 2).toUpperCase()"
-                zSize="md"
-                class="ring-border group-hover:ring-primary/30 relative ring-2 transition-all"
-              ></z-avatar>
-            </div>
-
-            <div class="flex min-w-0 flex-1 flex-col gap-2">
-              <div>
-                <h3 class="truncate text-base font-semibold">{{ maintainer.name }}</h3>
-                <p class="text-muted-foreground text-xs">{{ maintainer.role }}</p>
-              </div>
-
-              <div class="flex items-center gap-3">
-                <span
-                  class="text-muted-foreground group-hover:text-primary inline-flex items-center gap-1.5 text-xs transition-colors"
-                >
-                  <img [src]="githubData?.icon" [alt]="githubData?.iconAlt" class="h-3.5 dark:invert" />
-                  <span class="truncate font-mono">@{{ maintainer.login }}</span>
-                </span>
-              </div>
-            </div>
+          <div class="flex min-w-0 flex-col gap-0.5">
+            <h3 class="truncate text-sm font-medium">{{ maintainer.name }}</h3>
+            <span
+              class="text-muted-foreground group-hover:text-foreground inline-flex items-center gap-1.5 text-xs transition-colors"
+            >
+              <img [src]="githubData?.icon" [alt]="githubData?.iconAlt" class="h-3 dark:invert" />
+              <span class="truncate font-mono">{{ maintainer.login }}</span>
+            </span>
           </div>
         </a>
       }


### PR DESCRIPTION
## What was done? 📝

Simplify card layout with cleaner hover states, make entire cards clickable to open GitHub profiles, and add neopavan as maintainer.

## Screenshots or GIFs 📸
<img width="722" height="548" alt="image" src="https://github.com/user-attachments/assets/1ecb77e9-6e5d-4d5c-ae52-bd384a27beec" />

## Type of change 🏗

- [ ] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] Refactor (non-breaking change that improves the code or technical debt)
- [ ] Chore (none of the above, such as upgrading libraries)

## Checklist 🧐

- [x] Tested on Chrome
- [ ] Tested on Safari
- [x] Tested on Firefox
- [x] No errors in the console


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Redesigned founder and maintainer card layouts with improved responsive grid breakpoints.
  * Simplified card styling with cleaner visual hierarchy and updated spacing.
  * Refined avatar display and typography for a more compact, streamlined presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->