### PR TITLE
✨ feat(generators): add block scaffold generator and sync script

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
     "release": "npx nx release",
     "release:dry-run": "npx nx release --dry-run",
     "serve:ssr": "node dist/apps/web/server/server.mjs",
-    "generate:component": "nx generate @zardui/generators:component"
+    "generate:component": "nx generate @zardui/generators:component",
+    "generate:block": "nx generate @zardui/generators:block",
+    "sync:blocks": "npx tsx scripts/sync-blocks.ts"
   },
   "engines": {
     "node": ">=20.19.0"

--- a/scripts/sync-blocks.ts
+++ b/scripts/sync-blocks.ts
@@ -1,0 +1,116 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const BLOCKS_DIR = path.resolve(__dirname, '../libs/blocks/src/lib');
+
+function toCamelCase(name: string): string {
+  return name
+    .split('-')
+    .map((part, i) => (i === 0 ? part : part.charAt(0).toUpperCase() + part.slice(1)))
+    .join('');
+}
+
+function toClassName(name: string): string {
+  return name
+    .split('-')
+    .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+    .join('');
+}
+
+function escapeBackticks(content: string): string {
+  return content.replace(/\\/g, '\\\\').replace(/`/g, '\\`').replace(/\$\{/g, '\\${');
+}
+
+function syncBlock(blockDir: string, blockName: string): void {
+  const blockTsPath = path.join(blockDir, 'block.ts');
+  if (!fs.existsSync(blockTsPath)) return;
+
+  const blockContent = fs.readFileSync(blockTsPath, 'utf-8');
+
+  // Read component files (.ts and .html, excluding block.ts)
+  const componentFiles = fs
+    .readdirSync(blockDir)
+    .filter(f => f !== 'block.ts' && (f.endsWith('.ts') || f.endsWith('.html')))
+    .sort();
+
+  const filesEntries = componentFiles.map(fileName => {
+    const filePath = path.join(blockDir, fileName);
+    const content = fs.readFileSync(filePath, 'utf-8');
+    const language = fileName.endsWith('.ts') ? 'typescript' : 'html';
+
+    return `    {
+      name: '${fileName}',
+      path: 'src/components/${blockName}/${fileName}',
+      content: \`${escapeBackticks(content)}\`,
+      language: '${language}',
+    }`;
+  });
+
+  const filesArray = `[\n${filesEntries.join(',\n')},\n  ]`;
+
+  // Find `files:` and use bracket counting to locate the closing `]`
+  // Skips brackets inside backtick strings to handle embedded content
+  const filesIdx = blockContent.indexOf('files:');
+  if (filesIdx === -1) return;
+
+  const openBracketIdx = blockContent.indexOf('[', filesIdx);
+  if (openBracketIdx === -1) return;
+
+  let depth = 0;
+  let inBacktick = false;
+  let closeBracketIdx = -1;
+  for (let i = openBracketIdx; i < blockContent.length; i++) {
+    const ch = blockContent[i];
+    const prev = blockContent[i - 1];
+    if (ch === '`' && prev !== '\\') {
+      inBacktick = !inBacktick;
+      continue;
+    }
+    if (inBacktick) continue;
+    if (ch === '[') depth++;
+    else if (ch === ']') depth--;
+    if (depth === 0) {
+      closeBracketIdx = i;
+      break;
+    }
+  }
+  if (closeBracketIdx === -1) return;
+
+  const before = blockContent.slice(0, filesIdx);
+  const after = blockContent.slice(closeBracketIdx + 1);
+  const updatedContent = `${before}files: ${filesArray}${after}`;
+
+  if (updatedContent !== blockContent) {
+    fs.writeFileSync(blockTsPath, updatedContent, 'utf-8');
+    console.log(`  ✅ ${blockName}: synced ${componentFiles.length} files`);
+  } else {
+    console.log(`  ⏭️  ${blockName}: no changes`);
+  }
+}
+
+function main(): void {
+  console.log('🔄 Syncing block files...\n');
+
+  if (!fs.existsSync(BLOCKS_DIR)) {
+    console.error('❌ Blocks directory not found:', BLOCKS_DIR);
+    process.exit(1);
+  }
+
+  const blockDirs = fs.readdirSync(BLOCKS_DIR).filter(dir => fs.statSync(path.join(BLOCKS_DIR, dir)).isDirectory());
+
+  if (blockDirs.length === 0) {
+    console.log('  No blocks found.');
+    return;
+  }
+
+  for (const dir of blockDirs) {
+    syncBlock(path.join(BLOCKS_DIR, dir), dir);
+  }
+
+  console.log(`\n✅ Done! Synced ${blockDirs.length} block(s).`);
+}
+
+main();

--- a/tools/generators.json
+++ b/tools/generators.json
@@ -4,6 +4,11 @@
       "factory": "./generators/component",
       "schema": "./generators/component/schema.json",
       "description": "Generate a new Zard UI component"
+    },
+    "block": {
+      "factory": "./generators/block",
+      "schema": "./generators/block/schema.json",
+      "description": "Generate a new Zard UI block"
     }
   }
 }

--- a/tools/generators/block/files/__name__/__name__.component.html.template
+++ b/tools/generators/block/files/__name__/__name__.component.html.template
@@ -1,0 +1,3 @@
+<div class="flex min-h-screen items-center justify-center">
+  <p><%= title %></p>
+</div>

--- a/tools/generators/block/files/__name__/__name__.component.ts.template
+++ b/tools/generators/block/files/__name__/__name__.component.ts.template
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'lib-<%= name %>',
+  standalone: true,
+  imports: [],
+  templateUrl: './<%= name %>.component.html',
+})
+export class <%= className %>Component {}

--- a/tools/generators/block/files/__name__/block.ts.template
+++ b/tools/generators/block/files/__name__/block.ts.template
@@ -1,0 +1,16 @@
+import type { Block } from '@doc/domain/components/block-container/block-container.component';
+
+import { <%= className %>Component } from './<%= name %>.component';
+
+export const <%= camelName %>Block: Block = {
+  id: '<%= name %>',
+  title: '<%= title %>',
+  description: '<%= description %>',
+  component: <%= className %>Component,
+  category: '<%= category %>',
+  image: {
+    light: '/blocks/<%= name %>/light.png',
+    dark: '/blocks/<%= name %>/dark.png',
+  },
+  files: [],
+};

--- a/tools/generators/block/index.ts
+++ b/tools/generators/block/index.ts
@@ -1,0 +1,174 @@
+import { type Tree, formatFiles, generateFiles } from '@nx/devkit';
+import * as path from 'path';
+
+import type { BlockGeneratorSchema } from './schema';
+
+const BLOCKS_DIR = 'libs/blocks/src/lib';
+const INDEX_PATH = 'libs/blocks/src/index.ts';
+const REGISTRY_PATH = 'apps/web/src/app/domain/config/blocks-registry.ts';
+
+function toClassName(name: string): string {
+  return name
+    .split('-')
+    .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+    .join('');
+}
+
+function toCamelCase(name: string): string {
+  const pascal = toClassName(name);
+  return pascal.charAt(0).toLowerCase() + pascal.slice(1);
+}
+
+function toTitle(name: string): string {
+  // "sidebar-01" → "Sidebar", "authentication-02" → "Authentication"
+  const base = name.replace(/-\d+$/, '');
+  return base
+    .split('-')
+    .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+export default async function blockGenerator(tree: Tree, schema: BlockGeneratorSchema) {
+  const kebabName = schema.name.toLowerCase();
+  const className = toClassName(kebabName);
+  const camelName = toCamelCase(kebabName);
+  const title = toTitle(kebabName);
+  const category = schema.category || 'featured';
+
+  const templateVars = {
+    name: kebabName,
+    className,
+    camelName,
+    title,
+    description: schema.description,
+    category,
+    template: '',
+  };
+
+  // 1. Generate block files from templates
+  generateFiles(tree, path.join(__dirname, 'files'), BLOCKS_DIR, templateVars);
+
+  // 2. Populate files[] in block.ts with generated component content
+  populateBlockFiles(tree, kebabName);
+
+  // 3. Add exports to libs/blocks/src/index.ts
+  addExportsToIndex(tree, kebabName, className);
+
+  // 4. Add entry to BLOCKS_REGISTRY
+  addRegistryEntry(tree, kebabName, camelName, category);
+
+  await formatFiles(tree);
+}
+
+function escapeBackticks(content: string): string {
+  return content.replace(/\\/g, '\\\\').replace(/`/g, '\\`').replace(/\$\{/g, '\\${');
+}
+
+function populateBlockFiles(tree: Tree, name: string): void {
+  const blockDir = `${BLOCKS_DIR}/${name}`;
+  const blockTsPath = `${blockDir}/block.ts`;
+  const blockContent = tree.read(blockTsPath, 'utf-8');
+  if (!blockContent) return;
+
+  const componentFiles = [`${name}.component.ts`, `${name}.component.html`];
+  const filesEntries = componentFiles
+    .map(fileName => {
+      const content = tree.read(`${blockDir}/${fileName}`, 'utf-8');
+      if (!content) return null;
+      const language = fileName.endsWith('.ts') ? 'typescript' : 'html';
+      return `    {
+      name: '${fileName}',
+      path: 'src/components/${name}/${fileName}',
+      content: \`${escapeBackticks(content)}\`,
+      language: '${language}',
+    }`;
+    })
+    .filter(Boolean);
+
+  const filesArray = `[\n${filesEntries.join(',\n')},\n  ]`;
+
+  // Use bracket counting (backtick-aware) to find the closing `]` of files array
+  const filesIdx = blockContent.indexOf('files:');
+  if (filesIdx === -1) return;
+
+  const openBracketIdx = blockContent.indexOf('[', filesIdx);
+  if (openBracketIdx === -1) return;
+
+  let depth = 0;
+  let inBacktick = false;
+  let closeBracketIdx = -1;
+  for (let i = openBracketIdx; i < blockContent.length; i++) {
+    const ch = blockContent[i];
+    const prev = blockContent[i - 1];
+    if (ch === '`' && prev !== '\\') {
+      inBacktick = !inBacktick;
+      continue;
+    }
+    if (inBacktick) continue;
+    if (ch === '[') depth++;
+    else if (ch === ']') depth--;
+    if (depth === 0) {
+      closeBracketIdx = i;
+      break;
+    }
+  }
+  if (closeBracketIdx === -1) return;
+
+  const before = blockContent.slice(0, filesIdx);
+  const after = blockContent.slice(closeBracketIdx + 1);
+  tree.write(blockTsPath, `${before}files: ${filesArray}${after}`);
+}
+
+function addExportsToIndex(tree: Tree, name: string, className: string): void {
+  const content = tree.read(INDEX_PATH, 'utf-8');
+  if (!content) return;
+
+  const componentExport = `export * from './lib/${name}/${name}.component';`;
+  const blockExport = `export * from './lib/${name}/block';`;
+
+  if (content.includes(componentExport)) return;
+
+  const newContent = content.trimEnd() + '\n' + componentExport + '\n' + blockExport + '\n';
+  tree.write(INDEX_PATH, newContent);
+}
+
+function addRegistryEntry(tree: Tree, name: string, camelName: string, category: string): void {
+  const content = tree.read(REGISTRY_PATH, 'utf-8');
+  if (!content) return;
+
+  const blockVarName = `${camelName}Block`;
+
+  // Check if entry already exists
+  if (content.includes(blockVarName)) return;
+
+  // 1. Add import
+  const importLine = `import { ${blockVarName} } from '@blocks';`;
+  const lastImportIdx = content.lastIndexOf('import ');
+  const lastImportEnd = content.indexOf('\n', lastImportIdx);
+  const before = content.slice(0, lastImportEnd + 1);
+  const after = content.slice(lastImportEnd + 1);
+  let updated = before + importLine + '\n' + after;
+
+  // 2. Add to featured array (default category)
+  const featuredPattern = /featured:\s*\[([^\]]*)\]/;
+  const featuredMatch = updated.match(featuredPattern);
+  if (featuredMatch) {
+    const currentEntries = featuredMatch[1].trim();
+    const newEntries = currentEntries ? `${currentEntries}, ${blockVarName}` : blockVarName;
+    updated = updated.replace(featuredPattern, `featured: [${newEntries}]`);
+  }
+
+  // 3. Also add to the specific category if different from featured
+  if (category.toLowerCase() !== 'featured') {
+    const catKey = category.toLowerCase();
+    const catPattern = new RegExp(`(${catKey}:\\s*\\[)([^\\]]*)\\]`);
+    const catMatch = updated.match(catPattern);
+    if (catMatch) {
+      const currentEntries = catMatch[2].trim();
+      const newEntries = currentEntries ? `${currentEntries}, ${blockVarName}` : blockVarName;
+      updated = updated.replace(catPattern, `$1${newEntries}]`);
+    }
+  }
+
+  tree.write(REGISTRY_PATH, updated);
+}

--- a/tools/generators/block/schema.d.ts
+++ b/tools/generators/block/schema.d.ts
@@ -1,0 +1,5 @@
+export interface BlockGeneratorSchema {
+  name: string;
+  description: string;
+  category?: string;
+}

--- a/tools/generators/block/schema.json
+++ b/tools/generators/block/schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "cli": "nx",
+  "id": "block",
+  "title": "Generate a new Zard UI block",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Block name in kebab-case (e.g., 'sidebar-01')",
+      "x-prompt": "What is the block name?"
+    },
+    "description": {
+      "type": "string",
+      "description": "Short description of the block",
+      "x-prompt": "What does this block do?"
+    },
+    "category": {
+      "type": "string",
+      "description": "Block category (e.g., 'sidebar', 'login', 'signup')",
+      "default": "featured",
+      "x-prompt": "What category does this block belong to?"
+    }
+  },
+  "required": ["name", "description"]
+}


### PR DESCRIPTION
## What was done? 📝

Add Nx generator for block scaffolding with auto-populated files[] in block.ts, and sync-blocks script for re-syncing after edits. Uses bracket-counting parser to handle nested brackets in content.

## Type of change 🏗

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Refactor (non-breaking change that improves the code or technical debt)
- [ ] Chore (none of the above, such as upgrading libraries)

## Checklist 🧐

- [ ] Tested on Chrome
- [ ] Tested on Safari
- [ ] Tested on Firefox
- [x] No errors in the console


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Introduced automated synchronization tool to keep block configuration files aligned with actual component files, eliminating manual updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->