### PR TITLE
🐛 fix(dialog): remove hardcoded max-width for dialog variants

### DIFF
--- a/apps/web/public/installation/manual/dialog.md
+++ b/apps/web/public/installation/manual/dialog.md
@@ -213,7 +213,7 @@ export class ZardDialogComponent<T, U> extends BasePortalOutlet {
 import { cva, type VariantProps } from 'class-variance-authority';
 
 export const dialogVariants = cva(
-  'fixed left-[50%] top-[50%] z-50 grid w-full translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg rounded-lg max-w-[calc(100%-2rem)] sm:max-w-[425px]',
+  'fixed left-[50%] top-[50%] z-50 grid w-full translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg rounded-lg max-w-[calc(100%-2rem)]',
 );
 export type ZardDialogVariants = VariantProps<typeof dialogVariants>;
 

--- a/libs/zard/src/lib/shared/components/dialog/dialog.variants.ts
+++ b/libs/zard/src/lib/shared/components/dialog/dialog.variants.ts
@@ -1,6 +1,6 @@
 import { cva, type VariantProps } from 'class-variance-authority';
 
 export const dialogVariants = cva(
-  'fixed left-[50%] top-[50%] z-50 grid w-full translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg rounded-lg max-w-[calc(100%-2rem)] sm:max-w-[425px]',
+  'fixed left-[50%] top-[50%] z-50 grid w-full translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg rounded-lg max-w-[calc(100%-2rem)]',
 );
 export type ZardDialogVariants = VariantProps<typeof dialogVariants>;


### PR DESCRIPTION
## What was done? 📝

Removida a classe `sm:max-w-[425px]` hardcoded do `dialogVariants` (no arquivo `.ts` e na documentação). Isso evita o travamento da largura em telas maiores e permite que o tamanho do modal seja sobrescrito e customizado livremente via `class` externa.

## Screenshots or GIFs 📸

|-----Figma-----|
|-----Implementation-----|
| N/A | N/A |

## Link to Issue 🔗

Closes #491 

## Type of change 🏗

- [ ] New feature (non-breaking change that adds functionality)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Refactor (non-breaking change that improves the code or technical debt)
- [ ] Chore (none of the above, such as upgrading libraries)

## Breaking change 🚨

Nenhuma.

## Checklist 🧐

- [x] Tested on Chrome
- [ ] Tested on Safari
- [x] Tested on Firefox
- [x] No errors in the console

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Modified dialog width behavior on smaller screens and above for improved layout consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->