### PR TITLE
✨ feat(cli): use dynamic core paths for theme and provider imports

### DIFF
--- a/apps/web/src/app/domain/pages/themes/services/theme-generator.service.ts
+++ b/apps/web/src/app/domain/pages/themes/services/theme-generator.service.ts
@@ -83,7 +83,7 @@ export class ThemeGeneratorService {
     return `
 @layer ng-icon, theme, base, components, utilities;
 @import 'tailwindcss';
-@import './src/app/shared/core/css/tailwind.css';
+@import './app/shared/core/css/tailwind.css';
 @plugin "tailwindcss-animate";
 
 @custom-variant dark (&:is(.dark *));

--- a/packages/cli/src/commands/init/tailwind-setup.ts
+++ b/packages/cli/src/commands/init/tailwind-setup.ts
@@ -23,7 +23,10 @@ export async function createPostCssConfig(cwd: string): Promise<void> {
 export async function applyThemeToStyles(cwd: string, config: Config): Promise<void> {
   const stylesPath = path.join(cwd, config.tailwind.css);
   const selectedTheme = config.tailwind.baseColor;
-  const themeContent = getThemeContent(selectedTheme);
+  const parts = config.baseUrl.split('/');
+  const base = parts.length > 1 ? parts[1] : parts[0];
+  const corePath = './' + base + config.aliases.core.substring(1);
+  const themeContent = getThemeContent(selectedTheme, corePath);
 
   await writeFile(stylesPath, themeContent, 'utf8');
 }

--- a/packages/cli/src/commands/init/update-angular-config.ts
+++ b/packages/cli/src/commands/init/update-angular-config.ts
@@ -4,7 +4,9 @@ import { existsSync } from 'fs';
 import * as fsPromises from 'fs/promises';
 import * as path from 'path';
 
-const ZARD_PROVIDER_IMPORT = "import { provideZard } from '@/shared/core/provider/providezard';\n";
+const ZARD_PROVIDER_IMPORT = (corePath: string) => `
+import { provideZard } from '${corePath}/provider/providezard';
+`;
 const ZARD_PROVIDER_ENTRY = 'provideZard(),';
 
 /**
@@ -24,7 +26,7 @@ export async function updateAngularConfig(cwd: string, config: Config): Promise<
     let content: string = await fsPromises.readFile(appConfigPath, 'utf8');
 
     // Add new import at the top
-    if (!content.includes(ZARD_PROVIDER_IMPORT.trim())) {
+    if (!content.includes(ZARD_PROVIDER_IMPORT(config.aliases.core).trim())) {
       const importRegex = /^import .* from '.*';\n?/gm;
       let lastImportMatch: RegExpMatchArray | null = null;
       let match: RegExpMatchArray | null;
@@ -33,11 +35,12 @@ export async function updateAngularConfig(cwd: string, config: Config): Promise<
         lastImportMatch = match;
       }
 
-      if (lastImportMatch) {
+      if (lastImportMatch && lastImportMatch.index) {
         const insertionIndex = lastImportMatch.index + lastImportMatch[0].length;
-        content = content.slice(0, insertionIndex) + ZARD_PROVIDER_IMPORT + content.slice(insertionIndex);
+        content =
+          content.slice(0, insertionIndex) + ZARD_PROVIDER_IMPORT(config.aliases.core) + content.slice(insertionIndex);
       } else {
-        content = ZARD_PROVIDER_IMPORT + content;
+        content = ZARD_PROVIDER_IMPORT(config.aliases.core) + content;
       }
     } else {
       logger.warn('Import statement already exists. Skipping.');

--- a/packages/cli/src/core/themes/theme-definitions.ts
+++ b/packages/cli/src/core/themes/theme-definitions.ts
@@ -1,12 +1,15 @@
 export const availableThemes: string[] = ['neutral', 'stone', 'zinc', 'gray', 'slate'];
 
-const tailwindConfiguration = `
+const getTailwindConfiguration = (corePath: string): string => {
+  return `
 @layer ng-icon, theme, base, components, utilities;
 @import 'tailwindcss';
+@import '${corePath}/css/tailwind';
 @plugin "tailwindcss-animate";
 
 @custom-variant dark (&:is(.dark *));
 `;
+};
 
 const inlineTheme = `
 @theme inline {
@@ -88,8 +91,8 @@ const windowsScrollbar = `
 }
 `;
 
-export const neutral = `
-${tailwindConfiguration}
+export const neutral = (corePath: string) => `
+${getTailwindConfiguration(corePath)}
 
 :root {
   --radius: 0.625rem;
@@ -165,8 +168,8 @@ ${layerBase}
 ${windowsScrollbar}
 `;
 
-export const stone = `
-${tailwindConfiguration}
+export const stone = (corePath: string) => `
+${getTailwindConfiguration(corePath)}
 
 :root {
   --radius: 0.625rem;
@@ -242,8 +245,8 @@ ${layerBase}
 ${windowsScrollbar}
 `;
 
-export const zinc = `
-${tailwindConfiguration}
+export const zinc = (corePath: string) => `
+${getTailwindConfiguration(corePath)}
 
 :root {
   --radius: 0.625rem;
@@ -319,8 +322,8 @@ ${layerBase}
 ${windowsScrollbar}
 `;
 
-export const gray = `
-${tailwindConfiguration}
+export const gray = (corePath: string) => `
+${getTailwindConfiguration(corePath)}
 
 :root {
   --radius: 0.625rem;
@@ -396,8 +399,8 @@ ${layerBase}
 ${windowsScrollbar}
 `;
 
-export const slate = `
-${tailwindConfiguration}
+export const slate = (corePath: string) => `
+${getTailwindConfiguration(corePath)}
 
 :root {
   --radius: 0.625rem;

--- a/packages/cli/src/utils/theme-selector.ts
+++ b/packages/cli/src/utils/theme-selector.ts
@@ -4,20 +4,20 @@ export function getAvailableThemes(): string[] {
   return themes.availableThemes;
 }
 
-export function getThemeContent(themeName: string): string {
+export function getThemeContent(themeName: string, corePath: string): string {
   const content = (() => {
     switch (themeName) {
       case 'stone':
-        return themes.stone;
+        return themes.stone(corePath);
       case 'zinc':
-        return themes.zinc;
+        return themes.zinc(corePath);
       case 'gray':
-        return themes.gray;
+        return themes.gray(corePath);
       case 'slate':
-        return themes.slate;
+        return themes.slate(corePath);
       case 'neutral':
       default:
-        return themes.neutral;
+        return themes.neutral(corePath);
     }
   })();
 


### PR DESCRIPTION
## What was done? 📝

The CLI init command now dynamically resolves core import paths based on the user's project configuration (`config.aliases.core` and `config.baseUrl`) instead of using hardcoded paths. This ensures theme CSS and `provideZard` imports are correctly generated for any project structure.

- Theme definitions converted from static strings to functions accepting a `corePath` parameter
- `tailwind-setup.ts` resolves the core path from config with a guard for edge cases
- `update-angular-config.ts` uses dynamic path for the `provideZard` import
- `theme-generator.service.ts` fixed import path for the web app
- Removed `@angular/core` dependency from the CLI package (was incorrectly using `signal`/`computed` for string interpolation)

## Screenshots or GIFs 📸

N/A — CLI/internal changes, no visual changes.

## Link to Issue 🔗

<!-- provide the link to the related issue here -->

## Type of change 🏗

- [ ] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] Refactor (non-breaking change that improves the code or technical debt)
- [ ] Chore (none of the above, such as upgrading libraries)

## Breaking change 🚨

None.

## Checklist 🧐

- [x] Tested on Chrome
- [x] Tested on Safari
- [x] Tested on Firefox
- [x] No errors in the console