### PR TITLE
🐛 fix(web): skip prerender for llms.txt to avoid output collision

### DIFF
--- a/apps/web/src/app/app.routes.server.ts
+++ b/apps/web/src/app/app.routes.server.ts
@@ -10,6 +10,13 @@ export const serverRoutes: ServerRoute[] = [
     renderMode: RenderMode.Prerender,
   },
   {
+    // Served as a raw static file (public/llms.txt) and by the Express handler in
+    // server.ts. Must NOT be prerendered: doing so would try to create a
+    // `browser/llms.txt` directory that collides with the static file (EEXIST).
+    path: 'llms.txt',
+    renderMode: RenderMode.Server,
+  },
+  {
     path: '**',
     renderMode: RenderMode.Prerender,
   },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated `llms.txt` endpoint, served directly as a static file.
  * Ensured the endpoint is available through server rendering without generating conflicting prerendered output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->