### PR TITLE
🐛 fix(select): keep dropdown on screen when trigger is at viewport edge

### DIFF
--- a/apps/web-e2e/src/components/select.spec.ts
+++ b/apps/web-e2e/src/components/select.spec.ts
@@ -7,6 +7,18 @@ function getSelectTrigger(demoPage: ComponentDemoPage): Locator {
   return demoPage.firstDemoBox.locator('z-select [role="combobox"]').first();
 }
 
+/** Pins a select against the bottom edge of the viewport, away from the docs chrome. */
+async function pinToBottomEdge(select: Locator): Promise<void> {
+  await select.evaluate(element => {
+    const host = element as HTMLElement;
+    host.style.position = 'fixed';
+    host.style.left = '500px';
+    host.style.bottom = '8px';
+    host.style.width = '192px';
+    host.style.zIndex = '10';
+  });
+}
+
 async function openSelect(page: Page, demoPage: ComponentDemoPage): Promise<{ trigger: Locator; listbox: Locator }> {
   const trigger = getSelectTrigger(demoPage);
   await trigger.scrollIntoViewIfNeeded();
@@ -79,5 +91,35 @@ test.describe('Select component', () => {
   test('passes accessibility checks when open', async ({ page }) => {
     await openSelect(page, demoPage);
     await checkA11y(page, undefined, ['button-name', 'color-contrast', 'scrollable-region-focusable']);
+  });
+
+  test('opens an item-aligned listbox above a trigger at the bottom edge', async ({ page }) => {
+    await pinToBottomEdge(demoPage.firstDemoBox.locator('z-select').first());
+
+    const { trigger, listbox } = await openSelect(page, demoPage);
+
+    const listboxBox = await listbox.boundingBox();
+    const triggerBox = await trigger.boundingBox();
+    expect(listboxBox).not.toBeNull();
+    expect(listboxBox!.height).toBeGreaterThan(100);
+    expect(listboxBox!.y).toBeGreaterThanOrEqual(0);
+    // It must clear the trigger instead of covering it against the viewport edge.
+    expect(listboxBox!.y + listboxBox!.height).toBeLessThanOrEqual(triggerBox!.y + 1);
+    await expect(listbox.locator('[role="option"]').first()).toBeVisible();
+  });
+
+  test('flips a popper listbox above a trigger at the bottom edge', async ({ page }) => {
+    const select = page.locator('#scrollable z-select').first();
+    await pinToBottomEdge(select);
+
+    await select.locator('[role="combobox"]').click();
+
+    const listbox = page.locator('[data-slot="select-content"][role="listbox"]').last();
+    await expect(listbox).toBeVisible();
+    await expect(listbox).toHaveAttribute('data-side', 'top');
+
+    const listboxBox = await listbox.boundingBox();
+    const triggerBox = await select.locator('[role="combobox"]').boundingBox();
+    expect(listboxBox!.y + listboxBox!.height).toBeLessThanOrEqual(triggerBox!.y + 1);
   });
 });

--- a/libs/zard/src/lib/shared/components/select/select.component.spec.ts
+++ b/libs/zard/src/lib/shared/components/select/select.component.spec.ts
@@ -472,7 +472,8 @@ describe('ZardSelectComponent', () => {
       expect(overlayPane.style.minWidth).toBe('220px');
     }));
 
-    it('offsets item-aligned content so the selected option sits over the trigger', fakeAsync(() => {
+    /** Opens an item-aligned select with a trigger stubbed at `triggerTop` in the viewport. */
+    function openItemAlignedAt(triggerTop: number): { content: HTMLElement; offsets: Array<number | undefined> } {
       hostComponent.value.set('banana');
       hostFixture.detectChanges();
       const selectElement = hostFixture.debugElement.query(By.directive(ZardSelectComponent))
@@ -480,6 +481,8 @@ describe('ZardSelectComponent', () => {
       Object.defineProperty(selectElement, 'offsetWidth', { configurable: true, value: 220 });
       const trigger = hostFixture.nativeElement.querySelector('[data-slot="select-trigger"]') as HTMLButtonElement;
       Object.defineProperty(trigger, 'offsetHeight', { configurable: true, value: 36 });
+      trigger.getBoundingClientRect = () =>
+        ({ top: triggerTop, bottom: triggerTop + 36, height: 36 }) as unknown as DOMRect;
 
       trigger.click();
       const content = document.querySelector('[data-slot="select-content"]') as HTMLElement;
@@ -494,11 +497,24 @@ describe('ZardSelectComponent', () => {
       const overlayRef = selectComponent['overlayRef'] as unknown as {
         _positionStrategy: { positions: Array<{ offsetY?: number }> };
       };
-      const positionStrategy = overlayRef._positionStrategy;
+      return { content, offsets: overlayRef._positionStrategy.positions.map(position => position.offsetY) };
+    }
+
+    it('offsets item-aligned content so the selected option sits over the trigger', fakeAsync(() => {
+      const { content, offsets } = openItemAlignedAt(200);
+
       expect(content).toHaveAttribute('data-position', 'item-aligned');
       expect(content).toHaveAttribute('data-align-trigger', 'true');
-      expect(positionStrategy.positions[0].offsetY).toBe(-70);
-      expect(positionStrategy.positions[1].offsetY).toBe(62);
+      expect(offsets[0]).toBe(-70);
+      expect(offsets[1]).toBe(62);
+    }));
+
+    it('falls back to anchored positioning when item alignment would leave the viewport', fakeAsync(() => {
+      // Aligning the item would put the content bottom past the viewport, covering the trigger.
+      const { offsets } = openItemAlignedAt(window.innerHeight - 40);
+
+      expect(offsets[0]).toBe(4);
+      expect(offsets[1]).toBe(-4);
     }));
 
     it('emits zSelectionChange with the selected value', () => {

--- a/libs/zard/src/lib/shared/components/select/select.component.ts
+++ b/libs/zard/src/lib/shared/components/select/select.component.ts
@@ -1,11 +1,13 @@
 import {
   type ConnectedPosition,
+  type FlexibleConnectedPositionStrategy,
   Overlay,
   OverlayModule,
   OverlayPositionBuilder,
   type OverlayRef,
 } from '@angular/cdk/overlay';
 import { TemplatePortal } from '@angular/cdk/portal';
+import { ViewportRuler } from '@angular/cdk/scrolling';
 import { isPlatformBrowser } from '@angular/common';
 import {
   afterNextRender,
@@ -60,6 +62,8 @@ type OnTouchedType = () => void;
 type OnChangeType = (value: string | string[]) => void;
 
 const COMPACT_MODE_WIDTH_THRESHOLD = 100;
+const MAX_CONTENT_HEIGHT = 384; // max-h-96 equivalent
+const VIEWPORT_MARGIN = 8;
 let nextSelectId = 0;
 
 @Component({
@@ -193,6 +197,7 @@ export class ZardSelectComponent implements ControlValueAccessor, OnDestroy {
   private readonly overlayPositionBuilder = inject(OverlayPositionBuilder);
   private readonly viewContainerRef = inject(ViewContainerRef);
   private readonly platformId = inject(PLATFORM_ID);
+  private readonly viewportRuler = inject(ViewportRuler);
 
   readonly dropdownTemplate = viewChild.required<TemplateRef<void>>('dropdownTemplate');
   readonly optionsViewport = viewChild<ElementRef<HTMLElement>>('optionsViewport');
@@ -580,7 +585,10 @@ export class ZardSelectComponent implements ControlValueAccessor, OnDestroy {
     this.portal = new TemplatePortal(this.dropdownTemplate(), this.viewContainerRef);
 
     this.overlayRef.attach(this.portal);
-    this.overlayRef.updateSize(this.zPosition() === 'popper' ? { minWidth: hostWidth } : { width: hostWidth });
+    this.overlayRef.updateSize({
+      ...(this.zPosition() === 'popper' ? { minWidth: hostWidth } : { width: hostWidth }),
+      maxHeight: this.getAvailableContentHeight(),
+    });
     this.isOpen.set(true);
     this.updateFocusWhenNormalMode();
 
@@ -687,12 +695,9 @@ export class ZardSelectComponent implements ControlValueAccessor, OnDestroy {
       return;
     }
 
-    const itemAlignedOffset = this.getItemAlignedOffset();
-    if (!itemAlignedOffset) {
-      return;
-    }
-
-    this.overlayRef.updatePositionStrategy(this.createPositionStrategy(itemAlignedOffset));
+    // A null offset means the selected item cannot sit over the trigger without pushing the
+    // dropdown off screen, so the anchored placement is used instead and flips above the trigger.
+    this.overlayRef.updatePositionStrategy(this.createPositionStrategy(this.getItemAlignedOffset() ?? undefined));
   }
 
   private getItemAlignedOffset(): { bottom: number; top: number } | null {
@@ -708,22 +713,53 @@ export class ZardSelectComponent implements ControlValueAccessor, OnDestroy {
       return null;
     }
 
-    const triggerHeight = trigger.offsetHeight || trigger.getBoundingClientRect().height || this.triggerHeight();
+    const triggerRect = trigger.getBoundingClientRect();
+    const triggerHeight = trigger.offsetHeight || triggerRect.height || this.triggerHeight();
     const itemHeight = selectedItem.offsetHeight || selectedItem.getBoundingClientRect().height || triggerHeight;
     const contentHeight = content.offsetHeight || content.getBoundingClientRect().height;
     const selectedItemOffsetTop = selectedItem.offsetTop;
     const itemCenterOffset = (triggerHeight - itemHeight) / 2;
+
     const bottom = Math.round(-triggerHeight - selectedItemOffsetTop + itemCenterOffset);
     const top = Math.round(contentHeight - selectedItemOffsetTop + itemCenterOffset);
+
+    // Item alignment only holds while the whole dropdown stays on screen; otherwise it would
+    // cover the trigger against the viewport edge instead of opening next to it.
+    const viewportHeight = this.viewportRuler.getViewportSize().height;
+    const contentTop = triggerRect.bottom + bottom;
+    if (contentTop < VIEWPORT_MARGIN || contentTop + contentHeight > viewportHeight - VIEWPORT_MARGIN) {
+      return null;
+    }
 
     return { bottom, top };
   }
 
   private createPositionStrategy(itemAlignedOffset?: { bottom: number; top: number }) {
-    return this.overlayPositionBuilder
+    const positionStrategy = this.overlayPositionBuilder
       .flexibleConnectedTo(this.elementRef)
       .withPositions(this.connectedPositions(itemAlignedOffset))
-      .withPush(false);
+      // Without this the CDK shrinks the dropdown to whatever space is left below the
+      // trigger instead of flipping it, collapsing it to a sliver near the viewport edge.
+      .withFlexibleDimensions(false)
+      .withViewportMargin(VIEWPORT_MARGIN)
+      // Last resort for viewports too short for either side: nudge on screen instead of clipping.
+      .withPush(true);
+
+    this.trackOverlaySide(positionStrategy);
+
+    return positionStrategy;
+  }
+
+  private trackOverlaySide(positionStrategy: FlexibleConnectedPositionStrategy): void {
+    positionStrategy.positionChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(change => {
+      this.overlaySide.set(change.connectionPair.overlayY === 'bottom' ? 'top' : 'bottom');
+    });
+  }
+
+  /** Height the dropdown may occupy without overflowing the viewport. */
+  private getAvailableContentHeight(): number {
+    const viewportHeight = this.viewportRuler.getViewportSize().height;
+    return Math.max(Math.min(MAX_CONTENT_HEIGHT, viewportHeight - VIEWPORT_MARGIN * 2), 0);
   }
 
   private connectedPositions(itemAlignedOffset?: { bottom: number; top: number }): ConnectedPosition[] {
@@ -763,7 +799,7 @@ export class ZardSelectComponent implements ControlValueAccessor, OnDestroy {
           positionStrategy,
           hasBackdrop: false,
           scrollStrategy: this.overlay.scrollStrategies.reposition(),
-          maxHeight: 384, // max-h-96 equivalent
+          maxHeight: MAX_CONTENT_HEIGHT,
         });
         this.overlayRef
           .outsidePointerEvents()


### PR DESCRIPTION
Closes #670

The select dropdown collapsed into an ~8px sliver when the trigger sat at the bottom of the viewport: the CDK position strategy was left on default `flexibleDimensions`, so it shrank the overlay to the space left below the trigger instead of moving it.

## Changes

- `withFlexibleDimensions(false)` + `withViewportMargin(8)` — the overlay flips above the trigger instead of shrinking. `withPush(true)` nudges it on screen as a last resort in very short viewports.
- `item-aligned` now falls back to the anchored placement when aligning the selected item over the trigger would push the dropdown off screen — matching shadcn/Base UI `alignItemWithTrigger`. It no longer covers the trigger against the viewport edge.
- Overlay `maxHeight` is capped to the viewport height on open, so short viewports scroll instead of overflowing.
- `data-side` is now driven by CDK `positionChanges` (it was hardcoded to `bottom`), so the enter animation slides from the right direction when flipped.

Item alignment mid-page is unchanged: the selected item still sits over the trigger.

## Tests

2 unit tests (aligned offsets vs. anchored fallback) and 2 e2e tests (item-aligned and popper at the bottom edge).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved select dropdown positioning near the bottom edge of the viewport.
  - Dropdowns now open above their trigger when needed, without covering it or extending beyond the visible screen.
  - Added fallback positioning when item-aligned menus would overflow.
  - Dropdown height now adjusts to available space while maintaining comfortable viewport margins.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->